### PR TITLE
Updated toasts to have an offset property and added toast example to homepage

### DIFF
--- a/lib/services/toastManager.ts
+++ b/lib/services/toastManager.ts
@@ -31,10 +31,19 @@ export class ToastManager {
   }): Promise<any> {
     const duration = toastConfig.duration || DEFAULT_TOAST_DURATION;
 
+    const toastCls = ['notification-toast'];
+    if (toastConfig.cssClass) {
+      if (typeof toastConfig.cssClass === 'string') {
+        toastCls.push(toastConfig.cssClass);
+      } else {
+        toastCls.push(...toastConfig.cssClass);
+      }
+    }
+
     const toast = await toastController.create({
       header: I18n.translate(toastConfig.title),
       message: I18n.translate(toastConfig.message),
-      cssClass: toastConfig.cssClass,
+      cssClass: toastCls,
       mode: 'ios',
       duration: duration,
       icon: toastConfig.theme ? this._getIcon(toastConfig.theme) : toastConfig.icon,

--- a/lib/theme/components/toasts.scss
+++ b/lib/theme/components/toasts.scss
@@ -2,15 +2,17 @@
 
 /* **** Parsec toasts **** */
 
+@property --ms-toast-offset {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 0;
+}
+
 ion-toast.notification-toast {
   --background: none;
   --box-shadow: none;
   position: relative;
-
-  &--with-sidebar {
-    @extend ion-toast, .notification-toast;
-    --start: var(--parsec-sidebar-menu-width);
-  }
+  --start: var(--ms-toast-offset);
 
   &.ms-info {
     --ms-notification-toast-text-color: var(--parsec-color-light-info-700);

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -74,6 +74,13 @@
         "warning": "Warning",
         "error": "Error",
         "success": "Success"
+      },
+      "toast": {
+        "title": "Toast",
+        "open": "Show a toast",
+        "messageTitle": "A sample toast",
+        "message": "Just a sample toast to show what they look like.",
+        "offset": "Offset"
       }
     }
   },

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -74,6 +74,13 @@
         "warning": "Alerte",
         "error": "Erreur",
         "success": "Succès"
+      },
+      "toast": {
+        "title": "Toast",
+        "open": "Afficher un toast",
+        "messageTitle": "Un toast d'example",
+        "message": "Un simple petit toast d'exemple pour montrer leur apparence",
+        "offset": "Décalage"
       }
     }
   },

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -184,13 +184,25 @@
             slot="end"
           />
         </ion-item-divider>
+
+        <!-- toast-->
+        <ion-item-divider class="example-divider">
+          <ion-label class="title-h2">{{ $msTranslate('usage.components.toast.title') }}</ion-label>
+          <ms-input
+            label="usage.components.toast.offset"
+            v-model="toastOffset"
+          />
+          <ion-button @click="openToast">
+            {{ $msTranslate('usage.components.toast.open') }}
+          </ion-button>
+        </ion-item-divider>
       </div>
     </ion-content>
   </ion-page>
 </template>
 
 <script setup lang="ts">
-import { IonContent, IonLabel, IonPage, IonItemDivider, modalController } from '@ionic/vue';
+import { IonContent, IonLabel, IonPage, IonItemDivider, modalController, IonButton } from '@ionic/vue';
 import { cog, create, lockClosed, helpCircle, warning } from 'ionicons/icons';
 import {
   MsActionBar,
@@ -239,6 +251,7 @@ import { I18n } from '@lib/services/translation';
 import { DateTime } from 'luxon';
 import { ref, Ref } from 'vue';
 import SettingsModal from './settings/SettingsModal.vue';
+import { ToastManager } from '@lib/services';
 
 const msDropdownOptions: MsOptions = new MsOptions([
   {
@@ -263,6 +276,8 @@ const inputExample = ref('');
 const passwordInputExample = ref('');
 const searchIInputExample = ref('');
 const msReportTheme = ref(MsReportTheme.Info);
+const toastOffset = ref('0');
+const toastManager = new ToastManager();
 
 const msSorterOptions: MsOptions = new MsOptions([
   { label: 'usage.components.sorter.name', key: 'name' },
@@ -274,6 +289,7 @@ const msSorterLabels = {
   asc: 'FoldersPage.sort.asc',
   desc: 'FoldersPage.sort.desc',
 };
+
 interface MsSorterExampleData {
   name: string;
   birthDate: DateTime;
@@ -357,6 +373,16 @@ function onSortChange(event: MsSorterChangeEvent): void {
     } else {
       return a[sortKey] < b[sortKey] ? 1 : -1;
     }
+  });
+}
+
+async function openToast(): Promise<void> {
+  document.documentElement.style.setProperty('--ms-toast-offset', `${toastOffset.value}px`);
+
+  await toastManager.createAndPresent({
+    title: 'usage.components.toast.messageTitle',
+    message: 'usage.components.toast.message',
+    theme: MsReportTheme.Success,
   });
 }
 </script>


### PR DESCRIPTION
Property allows us to control the toast offset from the outside. Can't use `v-bind` because we're not inside a component.
Adding a `@property` in CSS gives us more control on what to do if the value set is not valid. It has been set as a length, meaning it will accept `12px` or `4.5em`, but it will just be ignored if it's not a valid CSS length value.

Closes #48 