### PR TITLE
Init i18n with plugin

### DIFF
--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -1,10 +1,14 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { TranslationPlugin } from '@lib/services';
+import { I18nConfig, TranslationPlugin } from '@lib/services';
 import { App } from 'vue';
 
+interface MegaSharkConfig {
+  i18n: I18nConfig;
+}
+
 export const MegaSharkPlugin = {
-  install: (app: App<any>): void => {
-    app.use(TranslationPlugin);
+  install: (app: App<any>, config: MegaSharkConfig): void => {
+    app.use(TranslationPlugin, config.i18n);
   },
 };

--- a/lib/services/translation.ts
+++ b/lib/services/translation.ts
@@ -21,7 +21,11 @@ export interface TranslationData {
 export type Translatable = string | TranslationData;
 
 export const TranslationPlugin = {
-  install: (app: App<any>): void => {
+  install: (app: App<any>, config: I18nConfig): void => {
+    const i18n = init(config);
+
+    app.use(i18n);
+
     app.config.globalProperties.$msTranslate = (translatable: Translatable | undefined): string => {
       return translate(translatable);
     };
@@ -32,7 +36,7 @@ export const TranslationPlugin = {
 export type Locale = 'fr-FR' | 'en-US';
 export type DateFormat = 'long' | 'short';
 
-interface I18nConfig {
+export interface I18nConfig {
   defaultLocale?: Locale;
   customAssets?: Record<Locale, object>;
 }
@@ -133,9 +137,9 @@ function getLocale(): any {
 }
 
 export const I18n = {
-  init,
   translate,
   formatDate,
   changeLocale,
   getLocale,
+  init,
 };

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -61,7 +61,9 @@
         "title": "Informative text"
       },
       "reportText": {
-        "title": "Report text"
+        "title": "Report text",
+        "message": "This is an example message and {important}.",
+        "important": "this is the important part"
       },
       "informationTooltip": {
         "title": "Information tooltip"
@@ -82,6 +84,11 @@
         "message": "Just a sample toast to show what they look like.",
         "offset": "Offset",
         "themeTitle": "Theme"
+      },
+      "translation": {
+        "title": "Translations",
+        "french": "Français",
+        "english": "English"
       }
     }
   },

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -61,7 +61,9 @@
         "title": "Informative text"
       },
       "reportText": {
-        "title": "Report text"
+        "title": "Report text",
+        "message": "Ceci est un message d'exemple et {important}.",
+        "important": "ceci est la partie importante"
       },
       "informationTooltip": {
         "title": "Information tooltip"
@@ -82,6 +84,11 @@
         "message": "Un simple petit toast d'exemple pour montrer leur apparence",
         "offset": "Décalage",
         "themeTitle": "Thème"
+      },
+      "translation": {
+        "title": "Traductions",
+        "french": "Français",
+        "english": "English"
       }
     }
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,21 +5,24 @@ import App from './App.vue';
 import router from './router';
 
 import { IonicVue } from '@ionic/vue';
-import { I18n, MegaSharkPlugin } from '@megashark';
+import { MegaSharkPlugin } from '@megashark';
 
 /* Theme variables */
 // Manual import since we're not using the built library
 import '@lib/theme/global.scss';
 
-I18n.init({
-  defaultLocale: 'en-US',
-  customAssets: {
-    'fr-FR': appFrFR,
-    'en-US': appEnUS,
-  },
-});
-
-const app = createApp(App).use(IonicVue).use(router).use(MegaSharkPlugin);
+const app = createApp(App)
+  .use(IonicVue)
+  .use(router)
+  .use(MegaSharkPlugin, {
+    i18n: {
+      defaultLocale: 'en-US',
+      customAssets: {
+        'fr-FR': appFrFR,
+        'en-US': appEnUS,
+      },
+    },
+  });
 
 router.isReady().then(() => {
   app.mount('#app');

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -2,6 +2,17 @@
   <ion-page>
     <ion-content :fullscreen="true">
       <div id="container">
+        <!-- translation -->
+        <ion-item-divider class="example-divider">
+          <ion-label class="title-h2">{{ $msTranslate('usage.components.translation.title') }}</ion-label>
+          <ms-dropdown
+            class="dropdown"
+            :options="localeOptions"
+            :default-option-key="I18n.getLocale()"
+            @change="I18n.changeLocale($event.option.key)"
+          />
+        </ion-item-divider>
+
         <!-- action-bar -->
         <ion-item-divider class="example-divider">
           <ion-label class="title-h2">{{ $msTranslate('usage.components.actionBar.title') }}</ion-label>
@@ -171,7 +182,14 @@
         <ion-item-divider class="example-divider">
           <ion-label class="title-h2">{{ $msTranslate('usage.components.reportText.title') }}</ion-label>
           <ms-report-text :theme="msReportTheme">
-            {{ $msTranslate('Authentication.keyringInfo') }}
+            <i18n-t
+              keypath="usage.components.reportText.message"
+              scope="global"
+            >
+              <template #important>
+                <strong>{{ $msTranslate('usage.components.reportText.important') }}</strong>
+              </template>
+            </i18n-t>
           </ms-report-text>
         </ion-item-divider>
 
@@ -198,7 +216,7 @@
               title="usage.components.toast.themeTitle"
               :options="msDropdownOptions"
               :default-option-key="toastTheme"
-              @change="onToastThemeChanged"
+              @change="toastTheme = $event.option.key"
             />
             <ion-button @click="openToast">
               {{ $msTranslate('usage.components.toast.open') }}
@@ -255,7 +273,6 @@ import {
   WavyCaretUp,
   ChevronExpand,
   DocumentImport,
-  MsDropdownChangeEvent,
 } from '@lib/components';
 import { I18n } from '@lib/services/translation';
 import { DateTime } from 'luxon';
@@ -279,6 +296,17 @@ const msDropdownOptions: MsOptions = new MsOptions([
   {
     key: MsReportTheme.Success,
     label: 'usage.components.msReportTheme.success',
+  },
+]);
+
+const localeOptions: MsOptions = new MsOptions([
+  {
+    key: 'en-US',
+    label: 'usage.components.translation.english',
+  },
+  {
+    key: 'fr-FR',
+    label: 'usage.components.translation.french',
   },
 ]);
 
@@ -385,10 +413,6 @@ function onSortChange(event: MsSorterChangeEvent): void {
       return a[sortKey] < b[sortKey] ? 1 : -1;
     }
   });
-}
-
-async function onToastThemeChanged(event: MsDropdownChangeEvent): Promise<void> {
-  toastTheme.value = event.option.key;
 }
 
 async function openToast(): Promise<void> {


### PR DESCRIPTION
- I18n initialization is done by the plugin (no need to import something else)
- i18n plugin is loaded by the app (it was missing)
- added an example on the home page of a report text using `i18n-t`
- added a locale switch on the home page