### PR TITLE
Handle fallthrough props on MsInput

### DIFF
--- a/lib/components/ms-input/MsAddressInput.vue
+++ b/lib/components/ms-input/MsAddressInput.vue
@@ -8,6 +8,7 @@
     @change="onChange"
     @ion-blur="onFocusLost"
     v-model="address"
+    :debounce="timeBeforeQuery"
   />
 </template>
 
@@ -46,7 +47,6 @@ defineExpose({
 const geoapifyApi = new GeoapifyAPI(props.geoapifyApiKey);
 const address = ref('');
 let querying = false;
-let timeoutId: number | undefined = undefined;
 
 function setValue(value: string): void {
   address.value = value;
@@ -89,15 +89,9 @@ async function onFocusLost(): Promise<void> {
 
 async function onChange(query: string): Promise<void> {
   emits('change', query);
-  if (timeoutId !== undefined) {
-    window.clearTimeout(timeoutId);
-  }
   if (query.length < props.minimumQueryLength || querying || props.queryOnFocusLost) {
     return;
   }
-  timeoutId = window.setTimeout(async () => {
-    timeoutId = undefined;
-    await doQuery(query);
-  }, props.timeBeforeQuery);
+  await doQuery(query);
 }
 </script>

--- a/lib/components/ms-input/MsInput.vue
+++ b/lib/components/ms-input/MsInput.vue
@@ -31,6 +31,7 @@
         @ion-blur="validate(modelValue || '')"
         @keyup.enter="enterPressed($event.target.value)"
         :disabled="$props.disabled"
+        v-bind="$attrs"
       />
     </div>
     <span


### PR DESCRIPTION
Makes it easier to pass props to `ion-ionput` that the MsInput was not meant to handle. A good example is to add
```
:maxlength="5"
:counter="true"
```
to a MsInput in the homepage. I also used it on the MsAddressInput to used the debounce prop instead of doing the setTimeout manually.