### PR TITLE
Updated how stripe is initialized

### DIFF
--- a/lib/components/ms-stripe/MsStripeCardElement.vue
+++ b/lib/components/ms-stripe/MsStripeCardElement.vue
@@ -40,7 +40,7 @@ import { card, lockClosed, calendarNumber } from 'ionicons/icons';
 import { LogoMastercard, LogoVisa, MsImage } from '@lib/components/ms-image';
 import { inject, onMounted, onUnmounted, ref } from 'vue';
 
-let stripeElement: StripeCardElementType;
+let stripeElement: StripeCardElementType | undefined;
 const stripeService: StripeService = inject(StripeServiceKey)!;
 const isValid = ref(false);
 const errorMessage = ref<string>('');
@@ -49,16 +49,16 @@ const props = defineProps<{
   type: 'cardNumber' | 'cardExpiry' | 'cardCvc';
 }>();
 
-onMounted(() => {
-  if (stripeService && stripeService.elements) {
-    stripeElement = stripeService.createCardElement(props.type, (event: StripeCardElementChangeEventType) => {
-      isValid.value = event.complete;
-      if (props.type === 'cardNumber') {
-        brand.value = (event as StripeCardNumberElementChangeEvent).brand;
-      }
-      errorMessage.value = event.error ? event.error.message : '';
-      emits('change', event);
-    });
+onMounted(async () => {
+  stripeElement = await stripeService.createCardElement(props.type, (event: StripeCardElementChangeEventType) => {
+    isValid.value = event.complete;
+    if (props.type === 'cardNumber') {
+      brand.value = (event as StripeCardNumberElementChangeEvent).brand;
+    }
+    errorMessage.value = event.error ? event.error.message : '';
+    emits('change', event);
+  });
+  if (stripeElement) {
     stripeElement.mount(`#${props.type}`);
   }
 });
@@ -95,7 +95,7 @@ function _getIcon(): string {
   }
 }
 
-function getStripeElement(): StripeCardElementType {
+function getStripeElement(): StripeCardElementType | undefined {
   return stripeElement;
 }
 

--- a/lib/components/ms-stripe/MsStripeCardForm.vue
+++ b/lib/components/ms-stripe/MsStripeCardForm.vue
@@ -35,15 +35,13 @@ const isValid = computed<boolean>(() => {
 });
 
 onMounted(async () => {
-  if (stripeService && stripeService.elements) {
-    if (cardNumberElement.value) {
-      await cardNumberElement.value.setFocus();
-    }
+  if (cardNumberElement.value) {
+    await cardNumberElement.value.setFocus();
   }
 });
 
 async function submit(billingDetails?: BillingDetails): Promise<PaymentMethodResult | undefined> {
-  if (isValid.value) {
+  if (isValid.value && cardNumberElement.value.getStripeElement()) {
     const data: any = {
       type: 'card',
       card: cardNumberElement.value.getStripeElement(),

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -186,7 +186,8 @@
       },
       "stripe": {
         "title": "Credit card with Stripe",
-        "submit": "Test"
+        "submit": "Test",
+        "notInit": "Make sure you are online."
       },
       "codeValidation": {
         "title": "Code validation"

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -186,7 +186,8 @@
       },
       "stripe": {
         "title": "Carte bancaire avec Stripe",
-        "submit": "Tester"
+        "submit": "Tester",
+        "notInit": "Veuillez vous assurer d'être connecté à internet"
       },
       "codeValidation": {
         "title": "Validation de code"

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -339,28 +339,33 @@
 
         <ion-item-divider class="example-divider">
           <ion-label class="title-h2">{{ $msTranslate('usage.components.stripe.title') }}</ion-label>
-          <div class="example-divider-content">
-            <div class="example-data">
-              <ms-stripe-card-form
-                class="stripe-card-form"
-                ref="stripeCardForm"
-              />
-              <ion-button
-                :disabled="!stripeCardForm?.isValid"
-                @click="createStripeCard"
-              >
-                {{ $msTranslate('usage.components.stripe.submit') }}
-              </ion-button>
+          <template v-if="stripeService.isInitialized()">
+            <div class="example-divider-content">
+              <div class="example-data">
+                <ms-stripe-card-form
+                  class="stripe-card-form"
+                  ref="stripeCardForm"
+                />
+                <ion-button
+                  :disabled="!stripeCardForm?.isValid"
+                  @click="createStripeCard"
+                >
+                  {{ $msTranslate('usage.components.stripe.submit') }}
+                </ion-button>
+              </div>
             </div>
-          </div>
-          <div
-            v-if="stripeCardDetails"
-            class="example-divider-content"
-          >
-            <div class="example-data">
-              <ms-stripe-card-details :card="stripeCardDetails" />
+            <div
+              v-if="stripeCardDetails"
+              class="example-divider-content"
+            >
+              <div class="example-data">
+                <ms-stripe-card-details :card="stripeCardDetails" />
+              </div>
             </div>
-          </div>
+          </template>
+          <template v-else>
+            {{ $msTranslate('usage.components.stripe.notInit') }}
+          </template>
         </ion-item-divider>
         <ion-item-divider class="example-divider">
           <ion-label class="title-h2">{{ $msTranslate('usage.components.summaryCard.title') }}</ion-label>


### PR DESCRIPTION
Currently, if Stripe inits fails (for being online for example), everything fails and the app will has to be restarted completly.

This makes Stripe initialization lazier, so that it will retry to init when needed (or it can be forced). Components will not try to display if it's not init.