### PR TITLE
Correctly set focus on CodeValidationInput mount

### DIFF
--- a/lib/components/ms-input/MsCodeValidationInput.vue
+++ b/lib/components/ms-input/MsCodeValidationInput.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onMounted, ref, defineEmits } from 'vue';
+import { onMounted, ref, defineEmits } from 'vue';
 import { IonInput, IonText } from '@ionic/vue';
 import { Ref } from 'vue';
 const inputs = ref();
@@ -46,8 +46,9 @@ const codes = ref<string[]>([]);
 const isFinalCodeValid: Ref<undefined | boolean> = ref(undefined);
 
 onMounted(async (): Promise<void> => {
-  await nextTick();
-  focusInputElement(getFirstInputElement());
+  setTimeout(() => {
+    focusInputElement(getFirstInputElement());
+  }, 200);
 });
 
 const props = defineProps<{


### PR DESCRIPTION
Closes https://github.com/Scille/parsec-sign/issues/157
An alternative to https://github.com/Scille/parsec-sign/pull/158
If the other PR is merged, we might as well delete the useless `nextTick` call