### PR TITLE
[MS] Adds window width composable

### DIFF
--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -6,6 +6,7 @@ import { App } from 'vue';
 interface MegaSharkConfig {
   i18n: I18nConfig;
   stripeConfig?: StripeConfig;
+  windowWidthThreshold?: number;
 }
 
 export class MegaSharkPlugin {
@@ -29,5 +30,6 @@ export class MegaSharkPlugin {
     }
     app.use(TranslationPlugin, this.config.i18n);
     app.use(this.stripePlugin);
+    app.provide('msWindowWidthThreshold', this.config.windowWidthThreshold);
   }
 }

--- a/lib/services/windowSize.ts
+++ b/lib/services/windowSize.ts
@@ -1,0 +1,31 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { ComputedRef, Ref, computed, inject, onMounted, onUnmounted, ref } from 'vue';
+
+interface _WindowSizeAttributes {
+  windowWidth: Ref<number>;
+  isLargeDisplay: ComputedRef<boolean>;
+  isSmallDisplay: ComputedRef<boolean>;
+}
+
+export function useWindowSize(): _WindowSizeAttributes {
+  const threshold = inject('msWindowWidthThreshold', 768);
+
+  const windowWidth = ref(window.innerWidth);
+  const isLargeDisplay = computed(() => windowWidth.value >= threshold);
+  const isSmallDisplay = computed(() => windowWidth.value < threshold);
+
+  const updateWidth = (): void => {
+    windowWidth.value = window.innerWidth;
+  };
+
+  onMounted(() => {
+    window.addEventListener('resize', updateWidth);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener('resize', updateWidth);
+  });
+
+  return { windowWidth, isLargeDisplay, isSmallDisplay };
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -249,6 +249,14 @@
       "disableLeft": "Disallow dragging left",
       "disableRight": "Disallow dragging right",
       "resetPosition": "Reset position"
+    },
+    "windowWidth": {
+      "title": "Window width",
+      "label": "Width: {width}px",
+      "largeWindow": "Is large window: {value}",
+      "smallWindow": "Is small window: {value}",
+      "shownOnLargeDisplays": "Only shown on large displays",
+      "shownOnSmallDisplays": "Only shown on small displays"
     }
   }
 }

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -249,6 +249,14 @@
       "disableLeft": "Interdire le déplacement vers la gauche",
       "disableRight": "Interdire le déplacement vers la droite",
       "resetPosition": "Réinitialiser la position"
+    },
+    "windowWidth": {
+      "title": "Largeur de fenêtre",
+      "label": "Largeur: {width}px",
+      "largeWindow": "Is large window: {value}",
+      "smallWindow": "Is small window: {value}",
+      "shownOnLargeDisplays": "Only shown on large displays",
+      "shownOnSmallDisplays": "Only shown on small displays"
     }
   }
 }

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -577,6 +577,30 @@
             </div>
           </div>
         </div>
+
+        <!-- window width -->
+        <div class="example-divider">
+          <ion-label class="title-h2">{{ $msTranslate('usage.windowWidth.title') }}</ion-label>
+          <div class="example-divider-content">
+            <div class="example-data">
+              <ion-label>{{ $msTranslate({ key: 'usage.windowWidth.label', data: { width: windowWidth } }) }}</ion-label>
+              <ion-label>{{ $msTranslate({ key: 'usage.windowWidth.largeWindow', data: { value: isLargeDisplay } }) }}</ion-label>
+              <ion-label>{{ $msTranslate({ key: 'usage.windowWidth.smallWindow', data: { value: isSmallDisplay } }) }}</ion-label>
+            </div>
+            <div
+              class="example-data"
+              v-show="isLargeDisplay"
+            >
+              {{ $msTranslate('usage.windowWidth.shownOnLargeDisplays') }}
+            </div>
+            <div
+              class="example-data"
+              v-show="isSmallDisplay"
+            >
+              {{ $msTranslate('usage.windowWidth.shownOnSmallDisplays') }}
+            </div>
+          </div>
+        </div>
       </div>
     </ion-content>
   </ion-page>
@@ -666,6 +690,8 @@ import {
   PaymentMethodResult,
 } from '@lib/services';
 import { Base64, IValidator, Validity } from '@lib/main';
+import { useWindowSize } from '@lib/services/windowSize';
+const { windowWidth, isLargeDisplay, isSmallDisplay } = useWindowSize();
 
 const referenceValue = ref<Answer>(Answer.No);
 


### PR DESCRIPTION
```
import { useWindowSize } from '@lib/services/windowSize';
const { windowWidth, isLargeDisplay, isSmallDisplay } = useWindowSize();
```
Then those values can be used like usual ref.

The threshold value can be set when initializing the megashark plugin.