### PR TITLE
feat(theme): introduce alias system, split colors into per-theme files

### DIFF
--- a/lib/components/ms-action-bar/MsActionBar.vue
+++ b/lib/components/ms-action-bar/MsActionBar.vue
@@ -227,8 +227,8 @@ onUnmounted(() => {
   margin: 0 1.25rem;
   padding: 0 1em;
   min-height: 3rem;
-  background-color: var(--parsec-color-light-secondary-background);
-  border-bottom: 1px solid var(--parsec-color-light-secondary-medium);
+  background-color: var(--parsec-color-secondary-background);
+  border-bottom: 1px solid var(--parsec-color-secondary-medium);
   border-radius: var(--parsec-radius-12);
   width: auto;
   width: -webkit-fill-available;
@@ -243,8 +243,8 @@ onUnmounted(() => {
 
 #action-bar-more-button {
   --background: transparent;
-  --background-hover: var(--parsec-color-light-secondary-medium);
-  --color: var(--parsec-color-light-secondary-text);
+  --background-hover: var(--parsec-color-secondary-medium);
+  --color: var(--parsec-color-secondary-text);
   margin-left: 0.5rem;
   min-height: 1rem;
 
@@ -254,20 +254,20 @@ onUnmounted(() => {
 
   .more-icon__ellipsis {
     font-size: 1.125rem;
-    color: var(--parsec-color-light-secondary-soft-text);
+    color: var(--parsec-color-secondary-soft-text);
   }
 
   .more-icon__chevron {
     margin-inline: 0em;
     margin-left: 0.375rem;
     font-size: 1rem;
-    color: var(--parsec-color-light-secondary-soft-text);
+    color: var(--parsec-color-secondary-soft-text);
   }
 
   &:hover {
     .more-icon__chevron,
     .more-icon__ellipsis {
-      color: var(--parsec-color-light-primary-600);
+      color: var(--parsec-color-primary-600);
     }
   }
 }

--- a/lib/components/ms-action-bar/MsActionBarButton.vue
+++ b/lib/components/ms-action-bar/MsActionBarButton.vue
@@ -61,14 +61,14 @@ function getWidth(): number {
   --padding-end: 0.5rem;
   --padding-bottom: 0.25rem;
   --padding-start: 0.5rem;
-  color: var(--parsec-color-light-secondary-soft-text);
-  --fill-color: var(--parsec-color-light-secondary-soft-text);
+  color: var(--parsec-color-secondary-soft-text);
+  --fill-color: var(--parsec-color-secondary-soft-text);
   border-radius: var(--parsec-radius-8);
 
   &:hover {
-    color: var(--parsec-color-light-primary-600);
-    --fill-color: var(--parsec-color-light-primary-600);
-    background: var(--parsec-color-light-secondary-medium);
+    color: var(--parsec-color-primary-600);
+    --fill-color: var(--parsec-color-primary-600);
+    background: var(--parsec-color-secondary-medium);
   }
 
   &-icon__left {

--- a/lib/components/ms-action-bar/MsActionBarPopover.vue
+++ b/lib/components/ms-action-bar/MsActionBarPopover.vue
@@ -55,9 +55,9 @@ async function handleClick(btn: any): Promise<void> {
 
 <style lang="scss" scoped>
 .list-action-bar-popover {
-  --background: var(--parsec-color-light-secondary-soft);
+  --background: var(--parsec-color-secondary-soft);
   --ion-item-background: transparent;
-  --ion-item-color: var(--parsec-color-light-secondary-soft-text);
+  --ion-item-color: var(--parsec-color-secondary-soft-text);
   --ion-item-border-color: transparent;
   padding: 0.5rem 0.25rem;
 
@@ -69,15 +69,15 @@ async function handleClick(btn: any): Promise<void> {
     padding: 0.5rem 0.5rem;
 
     &__label {
-      color: var(--parsec-color-light-secondary-soft-text);
+      color: var(--parsec-color-secondary-soft-text);
     }
 
     &__icon {
       font-size: 1.125rem;
       width: 1.125rem;
       height: 1.125rem;
-      --fill-color: var(--parsec-color-light-secondary-soft-text);
-      color: var(--parsec-color-light-secondary-soft-text);
+      --fill-color: var(--parsec-color-secondary-soft-text);
+      color: var(--parsec-color-secondary-soft-text);
     }
 
     &__icon--right {
@@ -95,12 +95,12 @@ async function handleClick(btn: any): Promise<void> {
     }
 
     &:hover {
-      background: var(--parsec-color-light-secondary-premiere);
+      background: var(--parsec-color-secondary-premiere);
 
       .item-content__icon,
       .item-content__label {
-        --fill-color: var(--parsec-color-light-primary-600);
-        color: var(--parsec-color-light-primary-600);
+        --fill-color: var(--parsec-color-primary-600);
+        color: var(--parsec-color-primary-600);
       }
     }
   }

--- a/lib/components/ms-card/MsSummaryCard.vue
+++ b/lib/components/ms-card/MsSummaryCard.vue
@@ -87,7 +87,7 @@ defineEmits<{
     z-index: 1;
 
     &__title {
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
   }
 

--- a/lib/components/ms-card/MsSummaryCardItem.vue
+++ b/lib/components/ms-card/MsSummaryCardItem.vue
@@ -42,11 +42,11 @@ defineProps<MsSummaryCardItemData>();
   }
 
   &__label {
-    color: var(--parsec-color-light-secondary-soft-grey);
+    color: var(--parsec-color-secondary-soft-grey);
   }
 
   &__text {
-    color: var(--parsec-color-light-secondary-text);
+    color: var(--parsec-color-secondary-text);
     display: block;
     gap: 0.5rem;
     overflow: hidden;

--- a/lib/components/ms-checkbox/MsCheckbox.vue
+++ b/lib/components/ms-checkbox/MsCheckbox.vue
@@ -118,7 +118,7 @@ async function onChange(_event: Event): Promise<void> {
 
   &:hover {
     .ms-checkbox {
-      outline: 1px solid var(--parsec-color-light-primary-300);
+      outline: 1px solid var(--parsec-color-primary-300);
       outline-offset: 2px;
     }
   }
@@ -132,8 +132,8 @@ async function onChange(_event: Event): Promise<void> {
   height: 20px;
   min-height: 20px;
   border-radius: var(--parsec-radius-6);
-  border: 2px solid var(--parsec-color-light-secondary-light);
-  background: var(--parsec-color-light-secondary-white);
+  border: 2px solid var(--parsec-color-secondary-light);
+  background: var(--parsec-color-secondary-surface);
   cursor: pointer;
   position: relative;
   display: grid;
@@ -154,7 +154,7 @@ async function onChange(_event: Event): Promise<void> {
     position: absolute;
     width: 6px;
     height: 2px;
-    background: var(--parsec-color-light-secondary-white);
+    background: var(--parsec-color-secondary-surface);
     opacity: 0;
     border-radius: 1px;
     transform: rotate(0deg) scale(1);
@@ -170,7 +170,7 @@ async function onChange(_event: Event): Promise<void> {
     position: absolute;
     width: 10px;
     height: 2px;
-    background: var(--parsec-color-light-secondary-white);
+    background: var(--parsec-color-secondary-surface);
     opacity: 0;
     border-radius: 1px;
     transform: rotate(0deg) scale(1);
@@ -184,13 +184,13 @@ async function onChange(_event: Event): Promise<void> {
   &-text {
     user-select: none;
     cursor: pointer;
-    color: var(--parsec-color-light-secondary-soft-text);
+    color: var(--parsec-color-secondary-soft-text);
   }
 }
 
 .ms-checkbox:checked {
-  background: var(--parsec-color-light-primary-600);
-  border-color: var(--parsec-color-light-primary-600);
+  background: var(--parsec-color-primary-600);
+  border-color: var(--parsec-color-primary-600);
 }
 
 .ms-checkbox:checked::before {
@@ -208,8 +208,8 @@ async function onChange(_event: Event): Promise<void> {
 }
 
 .ms-checkbox[ms-indeterminate='true'] {
-  background: var(--parsec-color-light-primary-600);
-  border-color: var(--parsec-color-light-primary-600);
+  background: var(--parsec-color-primary-600);
+  border-color: var(--parsec-color-primary-600);
 
   &::before {
     opacity: 1;

--- a/lib/components/ms-dropdown/MsAddressDropdown.vue
+++ b/lib/components/ms-dropdown/MsAddressDropdown.vue
@@ -42,8 +42,8 @@ defineEmits<{
   flex-direction: column;
   position: absolute;
   width: 100%;
-  border: 1px solid var(--parsec-color-light-secondary-light);
-  background: var(--parsec-color-light-secondary-white);
+  border: 1px solid var(--parsec-color-secondary-light);
+  background: var(--parsec-color-secondary-surface);
   border-radius: var(--parsec-radius-8);
   margin-top: 0.5rem;
   z-index: 12;
@@ -51,7 +51,7 @@ defineEmits<{
 
 .option {
   --background-hover: none;
-  --color: var(--parsec-color-light-secondary-grey);
+  --color: var(--parsec-color-secondary-grey);
   padding: 0.75rem 1rem;
   --background: none;
   --min-height: 0;
@@ -63,8 +63,8 @@ defineEmits<{
   cursor: pointer;
 
   &:hover:not(.item-disabled) {
-    background: var(--parsec-color-light-primary-30);
-    --background-hover: var(--parsec-color-light-primary-30);
+    background: var(--parsec-color-primary-30);
+    --background-hover: var(--parsec-color-primary-30);
   }
   &::part(native) {
     padding: 0;
@@ -75,7 +75,7 @@ defineEmits<{
     gap: 0.5rem;
 
     &__label {
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
   }
 }

--- a/lib/components/ms-dropdown/MsAddressDropdown.vue
+++ b/lib/components/ms-dropdown/MsAddressDropdown.vue
@@ -42,8 +42,8 @@ defineEmits<{
   flex-direction: column;
   position: absolute;
   width: 100%;
-  border: 1px solid var(--parsec-color-light-secondary-medium);
-  background: var(--parsec-color-light-secondary-white);
+  border: 1px solid var(--parsec-color-secondary-medium);
+  background: var(--parsec-color-secondary-surface);
   border-radius: var(--parsec-radius-8);
   margin-top: 0.5rem;
   z-index: 12;
@@ -76,10 +76,6 @@ defineEmits<{
 
     &__label {
       color: var(--parsec-color-secondary-text);
-    }
-
-    &__description {
-      color: var(--parsec-color-secondary-grey);
     }
 
     &__description {

--- a/lib/components/ms-dropdown/MsAddressDropdown.vue
+++ b/lib/components/ms-dropdown/MsAddressDropdown.vue
@@ -51,7 +51,7 @@ defineEmits<{
 
 .option {
   --background-hover: none;
-  --color: var(--parsec-color-light-secondary-hard-grey);
+  --color: var(--parsec-color-secondary-hard-grey);
   padding: 0.75rem 1rem;
   --background: none;
   --min-height: 0;
@@ -63,8 +63,8 @@ defineEmits<{
   cursor: pointer;
 
   &:hover:not(.item-disabled) {
-    background: var(--parsec-color-light-primary-30);
-    --background-hover: var(--parsec-color-light-primary-30);
+    background: var(--parsec-color-primary-30);
+    --background-hover: var(--parsec-color-primary-30);
   }
   &::part(native) {
     padding: 0;
@@ -75,11 +75,15 @@ defineEmits<{
     gap: 0.375rem;
 
     &__label {
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
 
     &__description {
-      color: var(--parsec-color-light-secondary-grey);
+      color: var(--parsec-color-secondary-grey);
+    }
+
+    &__description {
+      color: var(--parsec-color-secondary-grey);
     }
   }
 }

--- a/lib/components/ms-dropdown/MsDropdown.vue
+++ b/lib/components/ms-dropdown/MsDropdown.vue
@@ -134,7 +134,7 @@ function getIcon(): string {
 <style lang="scss" scoped>
 .dropdown-button {
   background: none;
-  color: var(--parsec-color-light-primary-800);
+  color: var(--parsec-color-secondary-text);
   margin: 0;
 
   .input-text {
@@ -145,14 +145,14 @@ function getIcon(): string {
 
   &::part(native) {
     border-radius: var(--parsec-radius-8);
-    border-color: var(--parsec-color-light-secondary-light);
+    border-color: var(--parsec-color-secondary-light);
     padding: 0 !important;
     --ripple-color: transparent;
   }
 
   &:hover {
     &::part(native) {
-      border-color: var(--parsec-color-light-primary-300);
+      border-color: var(--parsec-color-primary-300);
     }
   }
 
@@ -178,17 +178,17 @@ function getIcon(): string {
   gap: 0.5rem;
 
   .active {
-    --background: var(--parsec-color-light-secondary-background);
-    outline: var(--offset) solid var(--parsec-color-light-outline);
+    --background: var(--parsec-color-secondary-background);
+    outline: var(--offset) solid var(--parsec-color-outline);
     border-radius: var(--parsec-radius-8);
 
     &::part(native) {
-      border: 1px solid var(--parsec-color-light-primary-300);
+      border: 1px solid var(--parsec-color-primary-300);
     }
   }
 
   .form-label {
-    color: var(--parsec-color-light-primary-700);
+    color: var(--parsec-color-secondary-text);
   }
 
   &.large {
@@ -201,7 +201,7 @@ function getIcon(): string {
 .ms-dropdown-icon {
   font-size: 1.125rem;
   transition: transform ease-out 300ms;
-  color: var(--parsec-color-light-secondary-grey);
+  color: var(--parsec-color-secondary-grey);
 
   &.popover-is-open {
     transform: rotate(180deg);

--- a/lib/components/ms-dropdown/MsDropdown.vue
+++ b/lib/components/ms-dropdown/MsDropdown.vue
@@ -134,7 +134,7 @@ function getIcon(): string {
 <style lang="scss" scoped>
 .dropdown-button {
   background: none;
-  color: var(--parsec-color-secondary-text);
+  color: var(--parsec-color-primary-800);
   margin: 0;
 
   .input-text {
@@ -188,7 +188,7 @@ function getIcon(): string {
   }
 
   .form-label {
-    color: var(--parsec-color-secondary-text);
+    color: var(--parsec-color-primary-700);
   }
 
   &.large {

--- a/lib/components/ms-dropdown/MsDropdownPopover.vue
+++ b/lib/components/ms-dropdown/MsDropdownPopover.vue
@@ -68,7 +68,7 @@ async function onOptionClick(option: MsOption): Promise<void> {
 // eslint-disable-next-line vue-scoped-css/no-unused-selector
 .option {
   --background-hover: none;
-  --color: var(--parsec-color-light-secondary-grey);
+  --color: var(--parsec-color-secondary-grey);
   padding: 0.375rem 0.75rem;
   --background: none;
   border-radius: var(--parsec-radius-6);
@@ -79,8 +79,8 @@ async function onOptionClick(option: MsOption): Promise<void> {
   pointer-events: auto;
 
   &:hover:not(.item-disabled) {
-    background: var(--parsec-color-light-primary-50);
-    --background-hover: var(--parsec-color-light-primary-50);
+    background: var(--parsec-color-primary-50);
+    --background-hover: var(--parsec-color-primary-50);
   }
 
   &::part(native) {
@@ -94,7 +94,7 @@ async function onOptionClick(option: MsOption): Promise<void> {
     gap: 0.25rem;
 
     &__label {
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
   }
 
@@ -106,16 +106,16 @@ async function onOptionClick(option: MsOption): Promise<void> {
   &.selected {
     .option-text {
       &__label {
-        color: var(--parsec-color-light-primary-700);
+        color: var(--parsec-color-secondary-text);
       }
 
       &__description {
-        color: var(--parsec-color-light-secondary-grey);
+        color: var(--parsec-color-secondary-grey);
       }
     }
 
     .icon {
-      color: var(--parsec-color-light-primary-700);
+      color: var(--parsec-color-secondary-text);
     }
   }
 
@@ -127,11 +127,11 @@ async function onOptionClick(option: MsOption): Promise<void> {
       opacity: 0.5;
 
       &__label {
-        --color: var(--parsec-color-light-secondary-text);
+        --color: var(--parsec-color-secondary-text);
       }
 
       &__description {
-        --color: var(--parsec-color-light-secondary-grey);
+        --color: var(--parsec-color-secondary-grey);
       }
     }
 

--- a/lib/components/ms-dropdown/MsDropdownPopover.vue
+++ b/lib/components/ms-dropdown/MsDropdownPopover.vue
@@ -106,7 +106,7 @@ async function onOptionClick(option: MsOption): Promise<void> {
   &.selected {
     .option-text {
       &__label {
-        color: var(--parsec-color-secondary-text);
+        color: var(--parsec-color-primary-700);
       }
 
       &__description {
@@ -115,7 +115,7 @@ async function onOptionClick(option: MsOption): Promise<void> {
     }
 
     .icon {
-      color: var(--parsec-color-secondary-text);
+      color: var(--parsec-color-primary-700);
     }
   }
 

--- a/lib/components/ms-dropdown/MsSmallDisplayDropdown.vue
+++ b/lib/components/ms-dropdown/MsSmallDisplayDropdown.vue
@@ -142,11 +142,11 @@ async function cancel(): Promise<void> {
     padding: 0.5rem;
 
     &__label {
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
 
     &__description {
-      color: var(--parsec-color-light-secondary-grey);
+      color: var(--parsec-color-secondary-grey);
     }
   }
 
@@ -155,7 +155,7 @@ async function cancel(): Promise<void> {
       content: '';
       position: absolute;
       width: 100%;
-      outline: 1px solid var(--parsec-color-light-secondary-medium);
+      outline: 1px solid var(--parsec-color-secondary-medium);
     }
   }
 
@@ -163,28 +163,28 @@ async function cancel(): Promise<void> {
     content: '';
     position: absolute;
     width: 100%;
-    outline: 1px solid var(--parsec-color-light-secondary-medium);
+    outline: 1px solid var(--parsec-color-secondary-medium);
   }
 
   &:hover:not(.item-disabled) {
-    background: var(--parsec-color-light-secondary-background);
+    background: var(--parsec-color-secondary-background);
   }
 
   &.selected {
-    background: var(--parsec-color-light-secondary-background);
+    background: var(--parsec-color-secondary-background);
 
     .option-text {
       &__label {
-        color: var(--parsec-color-light-primary-700);
+        color: var(--parsec-color-secondary-text);
       }
 
       &__description {
-        color: var(--parsec-color-light-secondary-grey);
+        color: var(--parsec-color-secondary-grey);
       }
     }
 
     .icon {
-      color: var(--parsec-color-light-primary-700);
+      color: var(--parsec-color-secondary-text);
     }
   }
 
@@ -201,11 +201,11 @@ async function cancel(): Promise<void> {
       opacity: 0.5;
 
       &__label {
-        --color: var(--parsec-color-light-secondary-text);
+        --color: var(--parsec-color-secondary-text);
       }
 
       &__description {
-        --color: var(--parsec-color-light-secondary-grey);
+        --color: var(--parsec-color-secondary-grey);
       }
     }
 
@@ -224,7 +224,7 @@ async function cancel(): Promise<void> {
   padding: 1rem 1rem 2rem;
 
   &-cancel {
-    color: var(--parsec-color-light-secondary-text);
+    color: var(--parsec-color-secondary-text);
   }
 }
 </style>

--- a/lib/components/ms-dropdown/MsSmallDisplayDropdown.vue
+++ b/lib/components/ms-dropdown/MsSmallDisplayDropdown.vue
@@ -175,7 +175,7 @@ async function cancel(): Promise<void> {
 
     .option-text {
       &__label {
-        color: var(--parsec-color-secondary-text);
+        color: var(--parsec-color-primary-700);
       }
 
       &__description {
@@ -184,7 +184,7 @@ async function cancel(): Promise<void> {
     }
 
     .icon {
-      color: var(--parsec-color-secondary-text);
+      color: var(--parsec-color-primary-700);
     }
   }
 

--- a/lib/components/ms-image/MsImage.vue
+++ b/lib/components/ms-image/MsImage.vue
@@ -24,7 +24,7 @@ function isSvg(imageData: string): boolean {
 
 <style scoped lang="scss">
 .svg-container {
-  color: var(--fill-color, var(--parsec-color-light-primary-700));
+  color: var(--fill-color, var(--parsec-color-primary-700));
   display: flex;
 }
 </style>

--- a/lib/components/ms-input/MsChoosePasswordInput.vue
+++ b/lib/components/ms-input/MsChoosePasswordInput.vue
@@ -139,7 +139,7 @@ function clear(): void {
 }
 
 .info {
-  background: var(--parsec-color-light-primary-30);
+  background: var(--parsec-color-primary-30);
   display: flex;
   align-items: center;
   gap: 0.625rem;
@@ -154,7 +154,7 @@ function clear(): void {
   }
 
   &__text {
-    color: var(--parsec-color-light-secondary-text);
+    color: var(--parsec-color-secondary-text);
   }
 }
 
@@ -178,7 +178,7 @@ function clear(): void {
     display: flex;
     flex-direction: column;
     margin-top: 0.5rem;
-    color: var(--parsec-color-light-danger-500);
+    color: var(--parsec-color-danger-500);
   }
 }
 
@@ -188,7 +188,7 @@ function clear(): void {
   gap: 1rem;
 
   &__title {
-    color: var(--parsec-color-light-secondary-grey);
+    color: var(--parsec-color-secondary-grey);
   }
 
   &-list {
@@ -202,14 +202,14 @@ function clear(): void {
     align-items: center;
     padding: 0 0.5rem;
     gap: 0.5em;
-    background: var(--parsec-color-light-secondary-premiere);
-    color: var(--parsec-color-light-secondary-hard-grey);
+    background: var(--parsec-color-secondary-premiere);
+    color: var(--parsec-color-secondary-hard-grey);
     margin: 0;
     border-radius: var(--parsec-radius-12);
 
     &.matches {
-      color: var(--parsec-color-light-success-700);
-      background: var(--parsec-color-light-success-50);
+      color: var(--parsec-color-success-700);
+      background: var(--parsec-color-success-50);
       font-weight: 500;
     }
   }

--- a/lib/components/ms-input/MsCodeValidationInput.vue
+++ b/lib/components/ms-input/MsCodeValidationInput.vue
@@ -248,8 +248,8 @@ async function focusInputElement(input: HTMLIonInputElement | undefined): Promis
   }
   &__item {
     --highlight-color-focused: none;
-    color: var(--parsec-color-light-secondary-text);
-    background-color: var(--parsec-color-light-secondary-premiere);
+    color: var(--parsec-color-secondary-text);
+    background-color: var(--parsec-color-secondary-premiere);
     caret-color: transparent;
     border-radius: var(--parsec-radius-8);
     width: 3.5rem;
@@ -265,8 +265,8 @@ async function focusInputElement(input: HTMLIonInputElement | undefined): Promis
     }
 
     &:is(.has-focus) {
-      border: 1px solid var(--parsec-color-light-primary-200);
-      background: var(--parsec-color-light-secondary-inversed-contrast);
+      border: 1px solid var(--parsec-color-primary-200);
+      background: var(--parsec-color-secondary-inversed-contrast);
 
       &::after {
         content: '';
@@ -275,14 +275,14 @@ async function focusInputElement(input: HTMLIonInputElement | undefined): Promis
         left: 0;
         width: 100%;
         height: 100%;
-        outline: 5px solid var(--parsec-color-light-outline);
+        outline: 5px solid var(--parsec-color-outline);
         animation: blinking 1.4s infinite ease-out;
         border-radius: var(--parsec-radius-8);
       }
     }
 
     &:is(.has-value) {
-      background-color: var(--parsec-color-light-secondary-medium);
+      background-color: var(--parsec-color-secondary-medium);
     }
   }
 }
@@ -293,7 +293,7 @@ async function focusInputElement(input: HTMLIonInputElement | undefined): Promis
   gap: 0.5rem;
 
   &__invalid {
-    color: var(--parsec-color-light-danger-500);
+    color: var(--parsec-color-danger-500);
     margin-top: 0.75rem;
 
     @include ms.responsive-breakpoint('sm') {
@@ -302,7 +302,7 @@ async function focusInputElement(input: HTMLIonInputElement | undefined): Promis
   }
 
   &__valid {
-    color: var(--parsec-color-light-success-500);
+    color: var(--parsec-color-success-500);
     margin-top: 0.75rem;
 
     @include ms.responsive-breakpoint('sm') {

--- a/lib/components/ms-input/MsCodeValidationInput.vue
+++ b/lib/components/ms-input/MsCodeValidationInput.vue
@@ -247,8 +247,8 @@ async function focusInputElement(input: HTMLIonInputElement | undefined): Promis
   }
   &__item {
     --highlight-color-focused: none;
-    color: var(--parsec-color-light-secondary-text);
-    background-color: var(--parsec-color-light-secondary-premiere);
+    color: var(--parsec-color-secondary-text);
+    background-color: var(--parsec-color-secondary-premiere);
     caret-color: transparent;
     border-radius: var(--parsec-radius-8);
     width: 3.5rem;
@@ -264,8 +264,8 @@ async function focusInputElement(input: HTMLIonInputElement | undefined): Promis
     }
 
     &:is(.has-focus) {
-      border: 1px solid var(--parsec-color-light-primary-200);
-      background: var(--parsec-color-light-secondary-inversed-contrast);
+      border: 1px solid var(--parsec-color-primary-200);
+      background: var(--parsec-color-secondary-inversed-contrast);
 
       &::after {
         content: '';
@@ -274,14 +274,14 @@ async function focusInputElement(input: HTMLIonInputElement | undefined): Promis
         left: 0;
         width: 100%;
         height: 100%;
-        outline: 5px solid var(--parsec-color-light-outline);
+        outline: 5px solid var(--parsec-color-outline);
         animation: blinking 1.4s infinite ease-out;
         border-radius: var(--parsec-radius-8);
       }
     }
 
     &:is(.has-value) {
-      background-color: var(--parsec-color-light-secondary-medium);
+      background-color: var(--parsec-color-secondary-medium);
     }
   }
 }
@@ -292,7 +292,7 @@ async function focusInputElement(input: HTMLIonInputElement | undefined): Promis
   gap: 0.5rem;
 
   &__invalid {
-    color: var(--parsec-color-light-danger-500);
+    color: var(--parsec-color-danger-500);
     margin-top: 0.75rem;
 
     @include ms.responsive-breakpoint('sm') {
@@ -301,7 +301,7 @@ async function focusInputElement(input: HTMLIonInputElement | undefined): Promis
   }
 
   &__valid {
-    color: var(--parsec-color-light-success-500);
+    color: var(--parsec-color-success-500);
     margin-top: 0.75rem;
 
     @include ms.responsive-breakpoint('sm') {

--- a/lib/components/ms-input/MsSearchInput.vue
+++ b/lib/components/ms-input/MsSearchInput.vue
@@ -90,7 +90,7 @@ function onChange(value: any): void {
 
 <style scoped lang="scss">
 .ms-search-input {
-  border: 1px solid var(--parsec-color-light-secondary-disabled);
+  border: 1px solid var(--parsec-color-secondary-disabled);
   padding: 0.25rem 0 0.25rem 0.75rem;
   width: 100%;
   position: relative;

--- a/lib/components/ms-modal/MsModal.vue
+++ b/lib/components/ms-modal/MsModal.vue
@@ -160,7 +160,7 @@ async function confirm(): Promise<boolean> {
 
   &__title {
     padding: 0;
-    color: var(--parsec-color-light-secondary-text);
+    color: var(--parsec-color-secondary-text);
     display: flex;
     align-items: center;
     max-width: calc(100% - 2rem);
@@ -176,18 +176,18 @@ async function confirm(): Promise<boolean> {
       @include ms.responsive-breakpoint('sm') {
         padding: 1.5rem 2rem;
         margin-bottom: 1rem;
-        border-bottom: 1px solid var(--parsec-color-light-secondary-medium);
+        border-bottom: 1px solid var(--parsec-color-secondary-medium);
       }
     }
 
     &-icon {
-      color: var(--parsec-color-light-primary-600);
+      color: var(--parsec-color-primary-600);
       margin-right: 4px;
     }
   }
 
   &__text {
-    color: var(--parsec-color-light-secondary-soft-text);
+    color: var(--parsec-color-secondary-soft-text);
     margin-top: 0.625rem;
 
     @include ms.responsive-breakpoint('sm') {
@@ -258,23 +258,23 @@ async function confirm(): Promise<boolean> {
 }
 
 .ms-info {
-  --ms-modal-next-button-background-color: var(--parsec-color-light-secondary-text);
-  --ms-modal-next-button-background-hover-color: var(--parsec-color-light-secondary-contrast);
+  --ms-modal-next-button-background-color: var(--parsec-color-secondary-text);
+  --ms-modal-next-button-background-hover-color: var(--parsec-color-secondary-contrast);
 }
 
 .ms-success {
-  --ms-modal-next-button-background-color: var(--parsec-color-light-success-500);
-  --ms-modal-next-button-background-hover-color: var(--parsec-color-light-success-700);
+  --ms-modal-next-button-background-color: var(--parsec-color-success-500);
+  --ms-modal-next-button-background-hover-color: var(--parsec-color-success-700);
 }
 
 .ms-warning {
-  --ms-modal-next-button-background-color: var(--parsec-color-light-secondary-text);
-  --ms-modal-next-button-background-hover-color: var(--parsec-color-light-secondary-contrast);
+  --ms-modal-next-button-background-color: var(--parsec-color-secondary-text);
+  --ms-modal-next-button-background-hover-color: var(--parsec-color-secondary-contrast);
 }
 
 .ms-error {
-  --ms-modal-next-button-background-color: var(--parsec-color-light-danger-500);
-  --ms-modal-next-button-background-hover-color: var(--parsec-color-light-danger-700);
+  --ms-modal-next-button-background-color: var(--parsec-color-danger-500);
+  --ms-modal-next-button-background-hover-color: var(--parsec-color-danger-700);
 }
 
 .ms-info,

--- a/lib/components/ms-modal/MsModal.vue
+++ b/lib/components/ms-modal/MsModal.vue
@@ -146,7 +146,7 @@ async function confirm(): Promise<boolean> {
 
   &__title {
     padding: 0;
-    color: var(--parsec-color-light-secondary-text);
+    color: var(--parsec-color-secondary-text);
     display: flex;
     align-items: center;
     max-width: calc(100% - 2rem);
@@ -162,18 +162,18 @@ async function confirm(): Promise<boolean> {
       @include ms.responsive-breakpoint('sm') {
         padding: 1.5rem 2rem;
         margin-bottom: 1rem;
-        border-bottom: 1px solid var(--parsec-color-light-secondary-medium);
+        border-bottom: 1px solid var(--parsec-color-secondary-medium);
       }
     }
 
     &-icon {
-      color: var(--parsec-color-light-primary-600);
+      color: var(--parsec-color-primary-600);
       margin-right: 4px;
     }
   }
 
   &__subtitle {
-    color: var(--parsec-color-light-secondary-hard-grey);
+    color: var(--parsec-color-secondary-hard-grey);
   }
 }
 
@@ -233,6 +233,46 @@ async function confirm(): Promise<boolean> {
 
     .confirm-button-spinner {
       margin-left: 0.5rem;
+    }
+  }
+}
+
+.ms-info {
+  --ms-modal-next-button-background-color: var(--parsec-color-secondary-text);
+  --ms-modal-next-button-background-hover-color: var(--parsec-color-secondary-contrast);
+}
+
+.ms-success {
+  --ms-modal-next-button-background-color: var(--parsec-color-success-500);
+  --ms-modal-next-button-background-hover-color: var(--parsec-color-success-700);
+}
+
+.ms-warning {
+  --ms-modal-next-button-background-color: var(--parsec-color-secondary-text);
+  --ms-modal-next-button-background-hover-color: var(--parsec-color-secondary-contrast);
+}
+
+.ms-error {
+  --ms-modal-next-button-background-color: var(--parsec-color-danger-500);
+  --ms-modal-next-button-background-hover-color: var(--parsec-color-danger-700);
+}
+
+.ms-info,
+.ms-success,
+.ms-warning,
+.ms-error {
+  .ms-modal-header {
+    &__title-icon {
+      color: var(--ms-modal-title-text-color);
+    }
+  }
+
+  .ms-modal-footer {
+    margin-top: 0;
+
+    &-buttons #next-button {
+      --background: var(--ms-modal-next-button-background-color);
+      --background-hover: var(--ms-modal-next-button-background-hover-color);
     }
   }
 }

--- a/lib/components/ms-modal/MsModal.vue
+++ b/lib/components/ms-modal/MsModal.vue
@@ -236,44 +236,4 @@ async function confirm(): Promise<boolean> {
     }
   }
 }
-
-.ms-info {
-  --ms-modal-next-button-background-color: var(--parsec-color-secondary-text);
-  --ms-modal-next-button-background-hover-color: var(--parsec-color-secondary-contrast);
-}
-
-.ms-success {
-  --ms-modal-next-button-background-color: var(--parsec-color-success-500);
-  --ms-modal-next-button-background-hover-color: var(--parsec-color-success-700);
-}
-
-.ms-warning {
-  --ms-modal-next-button-background-color: var(--parsec-color-secondary-text);
-  --ms-modal-next-button-background-hover-color: var(--parsec-color-secondary-contrast);
-}
-
-.ms-error {
-  --ms-modal-next-button-background-color: var(--parsec-color-danger-500);
-  --ms-modal-next-button-background-hover-color: var(--parsec-color-danger-700);
-}
-
-.ms-info,
-.ms-success,
-.ms-warning,
-.ms-error {
-  .ms-modal-header {
-    &__title-icon {
-      color: var(--ms-modal-title-text-color);
-    }
-  }
-
-  .ms-modal-footer {
-    margin-top: 0;
-
-    &-buttons #next-button {
-      --background: var(--ms-modal-next-button-background-color);
-      --background-hover: var(--ms-modal-next-button-background-hover-color);
-    }
-  }
-}
 </style>

--- a/lib/components/ms-modal/MsSmallDisplayQuestionModal.vue
+++ b/lib/components/ms-modal/MsSmallDisplayQuestionModal.vue
@@ -95,7 +95,7 @@ async function cancel(): Promise<boolean> {
   &__title {
     padding: 0;
     margin-bottom: 1rem;
-    color: var(--parsec-color-light-primary-700);
+    color: var(--parsec-color-primary-700);
     display: flex;
     align-items: center;
     max-width: 22rem;
@@ -108,7 +108,7 @@ async function cancel(): Promise<boolean> {
   }
 
   &__text {
-    color: var(--parsec-color-light-secondary-soft-text);
+    color: var(--parsec-color-secondary-soft-text);
     font-weight: 400;
   }
 }
@@ -129,7 +129,7 @@ async function cancel(): Promise<boolean> {
 
     &-cancel {
       display: flex;
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
 
     &-confirm {

--- a/lib/components/ms-modal/MsSmallDisplayQuestionModal.vue
+++ b/lib/components/ms-modal/MsSmallDisplayQuestionModal.vue
@@ -123,7 +123,7 @@ async function cancel(): Promise<boolean> {
 
     #cancel-button {
       display: flex;
-      --background: var(--parsec-color-secondary-white) !important;
+      --background: var(--parsec-color-secondary-surface) !important;
       --color: var(--parsec-color-secondary-text) !important;
       --background-hover: var(--parsec-color-secondary-premiere) !important;
     }

--- a/lib/components/ms-modal/MsSmallDisplayQuestionModal.vue
+++ b/lib/components/ms-modal/MsSmallDisplayQuestionModal.vue
@@ -94,7 +94,7 @@ async function cancel(): Promise<boolean> {
   &__title {
     padding: 0;
     margin-bottom: 1rem;
-    color: var(--parsec-color-light-primary-700);
+    color: var(--parsec-color-primary-700);
     display: flex;
     align-items: center;
     max-width: 22rem;
@@ -102,7 +102,7 @@ async function cancel(): Promise<boolean> {
   }
 
   &__text {
-    color: var(--parsec-color-light-secondary-soft-text);
+    color: var(--parsec-color-secondary-soft-text);
     font-weight: 400;
   }
 }
@@ -123,9 +123,9 @@ async function cancel(): Promise<boolean> {
 
     #cancel-button {
       display: flex;
-      --background: var(--parsec-color-light-secondary-white) !important;
-      --color: var(--parsec-color-light-secondary-text) !important;
-      --background-hover: var(--parsec-color-light-secondary-premiere) !important;
+      --background: var(--parsec-color-secondary-white) !important;
+      --color: var(--parsec-color-secondary-text) !important;
+      --background-hover: var(--parsec-color-secondary-premiere) !important;
     }
 
     #confirm-button {

--- a/lib/components/ms-modal/MsSmallDisplayStepperModal.vue
+++ b/lib/components/ms-modal/MsSmallDisplayStepperModal.vue
@@ -89,7 +89,7 @@ async function cancel(): Promise<boolean> {
   &__title {
     padding: 0;
     margin-bottom: 1rem;
-    color: var(--parsec-color-light-primary-700);
+    color: var(--parsec-color-primary-700);
     display: flex;
     align-items: center;
     max-width: 22rem;
@@ -102,7 +102,7 @@ async function cancel(): Promise<boolean> {
   }
 
   &__text {
-    color: var(--parsec-color-light-secondary-soft-text);
+    color: var(--parsec-color-secondary-soft-text);
     font-weight: 400;
   }
 }
@@ -129,7 +129,7 @@ async function cancel(): Promise<boolean> {
       display: flex;
       margin: auto;
       font-size: medium;
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
 
     &-confirm {

--- a/lib/components/ms-modal/MsSmallDisplayStepperModal.vue
+++ b/lib/components/ms-modal/MsSmallDisplayStepperModal.vue
@@ -86,7 +86,7 @@ async function cancel(): Promise<boolean> {
   &__title {
     padding: 1.5rem;
     margin-bottom: 1rem;
-    color: var(--parsec-color-light-primary-700);
+    color: var(--parsec-color-primary-700);
     display: flex;
     align-items: center;
     max-width: 22rem;
@@ -94,7 +94,7 @@ async function cancel(): Promise<boolean> {
   }
 
   &__text {
-    color: var(--parsec-color-light-secondary-soft-text);
+    color: var(--parsec-color-secondary-soft-text);
     font-weight: 400;
   }
 }
@@ -121,7 +121,7 @@ async function cancel(): Promise<boolean> {
       display: flex;
       margin: auto;
       font-size: medium;
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
 
     &-confirm {

--- a/lib/components/ms-progress/MsProgress.vue
+++ b/lib/components/ms-progress/MsProgress.vue
@@ -56,14 +56,14 @@ const progressWidthStyle = computed(() => `${props.progress}%`);
   align-items: flex-start;
   width: 100%;
   height: 0.725rem;
-  background: var(--parsec-color-light-secondary-premiere);
+  background: var(--parsec-color-secondary-premiere);
   border-radius: var(--parsec-radius-8);
 
   .completed {
     transition: width 0.35s ease-in-out;
     width: v-bind(progressWidthStyle);
     height: 0.5rem;
-    background: var(--parsec-color-light-gradient);
+    background: var(--parsec-color-gradient);
     border-radius: var(--parsec-radius-6);
     flex: none;
     order: 0;
@@ -105,6 +105,6 @@ const progressWidthStyle = computed(() => `${props.progress}%`);
 }
 
 .progress-text {
-  color: var(--parsec-color-light-primary-600);
+  color: var(--parsec-color-primary-600);
 }
 </style>

--- a/lib/components/ms-slider/MsSlider.vue
+++ b/lib/components/ms-slider/MsSlider.vue
@@ -220,13 +220,13 @@ function updateCurrentProgress(event: MouseEvent, paused?: boolean): void {
     align-items: flex-start;
     width: 100%;
     height: 0.25rem;
-    background: var(--parsec-color-light-secondary-premiere);
+    background: var(--parsec-color-secondary-premiere);
     border-radius: var(--parsec-radius-8);
     transition: height 100ms ease-in;
 
     .full {
       width: v-bind(progressWidthStyle);
-      background: var(--parsec-color-light-primary-700);
+      background: var(--parsec-color-primary-700);
       opacity: 0.9;
       height: 0.25rem;
       border-radius: var(--parsec-radius-6);
@@ -245,14 +245,14 @@ function updateCurrentProgress(event: MouseEvent, paused?: boolean): void {
       cursor: pointer;
 
       .full {
-        background: var(--parsec-color-light-gradient);
+        background: var(--parsec-color-gradient);
 
         .dot {
           right: -0.275rem;
           top: -4px;
           height: 0.75rem;
           width: 0.75rem;
-          background-color: var(--parsec-color-light-primary-700);
+          background-color: var(--parsec-color-primary-700);
           border-radius: var(--parsec-radius-circle);
           box-shadow: var(--parsec-shadow-strong);
         }

--- a/lib/components/ms-sorter/MsSorter.vue
+++ b/lib/components/ms-sorter/MsSorter.vue
@@ -92,7 +92,7 @@ async function onDidDismissPopover(popover: any): Promise<void> {
 .sorter-button {
   --background: transparent;
   --background-hover: transparent;
-  --color: var(--parsec-color-light-secondary-hard-grey);
+  --color: var(--parsec-color-secondary-hard-grey);
   min-height: 1rem;
 
   &::part(native) {
@@ -112,7 +112,7 @@ async function onDidDismissPopover(popover: any): Promise<void> {
     }
 
     &__icon {
-      color: var(--parsec-color-light-secondary-hard-grey);
+      color: var(--parsec-color-secondary-hard-grey);
       font-size: 1rem;
 
       @include ms.responsive-breakpoint('sm') {
@@ -121,22 +121,22 @@ async function onDidDismissPopover(popover: any): Promise<void> {
     }
 
     &__text {
-      color: var(--parsec-color-light-secondary-hard-grey);
+      color: var(--parsec-color-secondary-hard-grey);
       font-size: 0.8125rem;
       font-weight: 500;
     }
 
     &:hover .sorter-button-content__icon {
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
   }
 
   &:hover {
     .sorter-button-content {
-      background: var(--parsec-color-light-secondary-medium);
+      background: var(--parsec-color-secondary-medium);
 
       &__text {
-        color: var(--parsec-color-light-secondary-text);
+        color: var(--parsec-color-secondary-text);
       }
     }
   }

--- a/lib/components/ms-sorter/MsSorterPopover.vue
+++ b/lib/components/ms-sorter/MsSorterPopover.vue
@@ -91,7 +91,7 @@ function getSorterLabel(): Translatable {
 
 #sort-order-button {
   --background: none;
-  --color: var(--parsec-color-light-secondary-grey);
+  --color: var(--parsec-color-secondary-grey);
   --border-radius: var(--parsec-radius-4);
   --padding-top: 0.375rem;
   --padding-bottom: 0.375rem;
@@ -102,7 +102,7 @@ function getSorterLabel(): Translatable {
   width: 100%;
   margin-left: auto;
   transition: transform 0.2s ease-in-out;
-  border-bottom: 1px solid var(--parsec-color-light-secondary-disabled);
+  border-bottom: 1px solid var(--parsec-color-secondary-disabled);
   cursor: pointer;
 
   &::part(native) {
@@ -111,17 +111,17 @@ function getSorterLabel(): Translatable {
   }
 
   &:hover {
-    background: var(--parsec-color-light-secondary-background);
+    background: var(--parsec-color-secondary-background);
     --background-hover: none;
-    --color-hover: var(--parsec-color-light-secondary-text);
+    --color-hover: var(--parsec-color-secondary-text);
 
     ion-icon {
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
   }
 
   ion-icon {
-    color: var(--parsec-color-light-secondary-grey);
+    color: var(--parsec-color-secondary-grey);
     margin: 0;
     padding-left: 0.375rem;
     font-size: 1rem;
@@ -134,16 +134,16 @@ function getSorterLabel(): Translatable {
   flex-direction: column;
 
   &__title {
-    color: var(--parsec-color-light-secondary-grey);
+    color: var(--parsec-color-secondary-grey);
     opacity: 0.7;
     margin-bottom: 0.5rem;
   }
 
   &-item {
-    --background-hover: var(--parsec-color-light-primary-30);
+    --background-hover: var(--parsec-color-primary-30);
     --background-hover-opacity: 1;
-    --color: var(--parsec-color-light-secondary-soft-text);
-    --color-hover: var(--parsec-color-light-primary-600);
+    --color: var(--parsec-color-secondary-soft-text);
+    --color-hover: var(--parsec-color-primary-600);
     --border-radius: var(--parsec-radius-6);
     --padding-top: 0.375rem;
     --padding-bottom: 0.375rem;
@@ -152,8 +152,8 @@ function getSorterLabel(): Translatable {
     --inner-padding-end: 0;
 
     &.selected {
-      color: var(--parsec-color-light-primary-700);
-      --color-hover: var(--parsec-color-light-primary-700);
+      color: var(--parsec-color-primary-700);
+      --color-hover: var(--parsec-color-primary-700);
       --background-hover: none;
 
       span {
@@ -161,7 +161,7 @@ function getSorterLabel(): Translatable {
       }
     }
     .checked.selected {
-      color: var(--parsec-color-light-primary-700);
+      color: var(--parsec-color-primary-700);
     }
 
     ion-icon {

--- a/lib/components/ms-spinner/MsSpinner.vue
+++ b/lib/components/ms-spinner/MsSpinner.vue
@@ -39,7 +39,7 @@ const spinnerSizeFormatted = computed(() => `${spinnerSize.value}px`);
   gap: 0.5rem;
 
   &-text {
-    color: var(--parsec-color-light-secondary-grey);
+    color: var(--parsec-color-secondary-grey);
   }
 }
 
@@ -65,7 +65,7 @@ const spinnerSizeFormatted = computed(() => `${spinnerSize.value}px`);
 }
 
 .circular-progress circle.bg {
-  stroke: var(--parsec-color-light-primary-50);
+  stroke: var(--parsec-color-primary-50);
 }
 
 .circular-progress circle.fg {
@@ -73,7 +73,7 @@ const spinnerSizeFormatted = computed(() => `${spinnerSize.value}px`);
   transform-origin: var(--half-size) var(--half-size);
   stroke-dasharray: var(--dash) calc(var(--circumference) - var(--dash));
   transition: stroke-dasharray 0.3s linear 0s;
-  stroke: var(--parsec-color-light-primary-500);
+  stroke: var(--parsec-color-primary-500);
 }
 
 @property --progress {

--- a/lib/components/ms-spinner/MsSpinner.vue
+++ b/lib/components/ms-spinner/MsSpinner.vue
@@ -39,7 +39,7 @@ const spinnerSizeFormatted = computed(() => `${spinnerSize.value}px`);
   gap: 0.5rem;
 
   &-text {
-    color: var(--parsec-color-light-secondary-hard-grey);
+    color: var(--parsec-color-secondary-hard-grey);
   }
 }
 
@@ -65,7 +65,7 @@ const spinnerSizeFormatted = computed(() => `${spinnerSize.value}px`);
 }
 
 .circular-progress circle.bg {
-  stroke: var(--parsec-color-light-primary-50);
+  stroke: var(--parsec-color-primary-50);
 }
 
 .circular-progress circle.fg {
@@ -73,7 +73,7 @@ const spinnerSizeFormatted = computed(() => `${spinnerSize.value}px`);
   transform-origin: var(--half-size) var(--half-size);
   stroke-dasharray: var(--dash) calc(var(--circumference) - var(--dash));
   transition: stroke-dasharray 0.3s linear 0s;
-  stroke: var(--parsec-color-light-primary-500);
+  stroke: var(--parsec-color-primary-500);
 }
 
 @property --progress {

--- a/lib/components/ms-stepper/MsWizardStepper.vue
+++ b/lib/components/ms-stepper/MsWizardStepper.vue
@@ -40,7 +40,7 @@ defineProps<{
 <!-- eslint-disable-next-line vue-scoped-css/enforce-style-type -->
 <style lang="scss">
 .ms-wizard-stepper {
-  background: var(--parsec-color-light-secondary-background);
+  background: var(--parsec-color-secondary-background);
   display: flex;
   padding: 2rem 1rem;
   justify-content: center;
@@ -53,7 +53,7 @@ defineProps<{
     width: 8.125rem;
 
     .step-title {
-      color: var(--parsec-color-light-primary-600);
+      color: var(--parsec-color-primary-600);
     }
 
     .done {
@@ -61,7 +61,7 @@ defineProps<{
     }
 
     .default {
-      color: var(--parsec-color-light-secondary-grey);
+      color: var(--parsec-color-secondary-grey);
     }
 
     &:first-of-type {

--- a/lib/components/ms-stepper/MsWizardStepperStep.vue
+++ b/lib/components/ms-stepper/MsWizardStepperStep.vue
@@ -66,21 +66,21 @@ function getClass(status: MsStepStatus): string {
     height: 1.5px;
   }
   .left-line {
-    background: var(--parsec-color-light-primary-600);
+    background: var(--parsec-color-primary-600);
   }
   .circle {
-    background: var(--parsec-color-light-secondary-background);
+    background: var(--parsec-color-secondary-background);
     width: 1rem;
     height: 1rem;
     border-radius: var(--parsec-radius-circle);
-    border: 1.5px solid var(--parsec-color-light-primary-600);
+    border: 1.5px solid var(--parsec-color-primary-600);
     position: relative;
     display: flex;
     justify-content: center;
     align-items: center;
   }
   .right-line {
-    background: var(--parsec-color-light-secondary-soft-grey);
+    background: var(--parsec-color-secondary-soft-grey);
   }
 }
 
@@ -88,13 +88,13 @@ function getClass(status: MsStepStatus): string {
   opacity: 0.5;
 
   .right-line {
-    background: var(--parsec-color-light-primary-600);
+    background: var(--parsec-color-primary-600);
   }
 
   .circle {
-    background: var(--parsec-color-light-primary-600);
+    background: var(--parsec-color-primary-600);
     .icon-checkmark {
-      color: var(--parsec-color-light-secondary-white);
+      color: var(--parsec-color-secondary-white);
     }
   }
 }
@@ -104,9 +104,9 @@ function getClass(status: MsStepStatus): string {
     opacity: 0.5;
   }
   .circle {
-    background: var(--parsec-color-light-secondary-background);
+    background: var(--parsec-color-secondary-background);
     .inner-circle-active {
-      background: var(--parsec-color-light-primary-600);
+      background: var(--parsec-color-primary-600);
       width: 0.5rem;
       height: 0.5rem;
       border-radius: var(--parsec-radius-32);
@@ -114,16 +114,16 @@ function getClass(status: MsStepStatus): string {
     }
   }
   .right-line {
-    background: var(--parsec-color-light-secondary-soft-grey);
+    background: var(--parsec-color-secondary-soft-grey);
   }
 }
 
 .default {
   .left-line {
-    background: var(--parsec-color-light-secondary-soft-grey);
+    background: var(--parsec-color-secondary-soft-grey);
   }
   .circle {
-    border-color: var(--parsec-color-light-secondary-grey);
+    border-color: var(--parsec-color-secondary-grey);
 
     .inner-circle-done {
       width: 0.5rem;

--- a/lib/components/ms-stepper/MsWizardStepperStep.vue
+++ b/lib/components/ms-stepper/MsWizardStepperStep.vue
@@ -94,7 +94,7 @@ function getClass(status: MsStepStatus): string {
   .circle {
     background: var(--parsec-color-primary-600);
     .icon-checkmark {
-      color: var(--parsec-color-secondary-white);
+      color: var(--parsec-color-secondary-surface);
     }
   }
 }

--- a/lib/components/ms-stripe/MsStripeCardDetails.vue
+++ b/lib/components/ms-stripe/MsStripeCardDetails.vue
@@ -76,7 +76,7 @@ function getBrandImageUrl(brand: string): string {
     letter-spacing: 0.15em;
 
     p {
-      color: var(--parsec-color-light-secondary-white);
+      color: var(--parsec-color-secondary-white);
       margin: 0;
     }
 
@@ -112,14 +112,14 @@ function getBrandImageUrl(brand: string): string {
       flex-direction: column;
 
       .number-digits {
-        color: var(--parsec-color-light-secondary-soft-text);
+        color: var(--parsec-color-secondary-soft-text);
         font-size: 1rem;
         font-weight: 500;
         margin: 0;
       }
 
       .number-expiration {
-        color: var(--parsec-color-light-secondary-hard-grey);
+        color: var(--parsec-color-secondary-hard-grey);
         font-size: 0.875rem;
         margin: 0;
       }

--- a/lib/components/ms-stripe/MsStripeCardDetails.vue
+++ b/lib/components/ms-stripe/MsStripeCardDetails.vue
@@ -76,7 +76,7 @@ function getBrandImageUrl(brand: string): string {
     letter-spacing: 0.15em;
 
     p {
-      color: var(--parsec-color-secondary-white);
+      color: var(--parsec-color-secondary-surface);
       margin: 0;
     }
 

--- a/lib/components/ms-stripe/MsStripeCardElement.vue
+++ b/lib/components/ms-stripe/MsStripeCardElement.vue
@@ -144,18 +144,18 @@ defineExpose({
   flex-grow: unset;
 
   &:has(.StripeElement--focus) {
-    border: 1px solid var(--parsec-color-light-primary-400);
-    background: var(--parsec-color-light-secondary-white);
-    outline: 0.25rem solid var(--parsec-color-light-outline);
+    border: 1px solid var(--parsec-color-primary-400);
+    background: var(--parsec-color-secondary-surface);
+    outline: 0.25rem solid var(--parsec-color-outline);
   }
 }
 
 .icon {
   font-size: 1.125em;
-  color: var(--parsec-color-light-secondary-light);
+  color: var(--parsec-color-secondary-light);
 
   &-error {
-    color: var(--parsec-color-light-danger-500);
+    color: var(--parsec-color-danger-500);
   }
 }
 </style>

--- a/lib/components/ms-stripe/MsStripeCardForm.vue
+++ b/lib/components/ms-stripe/MsStripeCardForm.vue
@@ -151,7 +151,7 @@ defineExpose({
 
   .icon {
     font-size: 1.125em;
-    color: var(--parsec-color-light-secondary-light);
+    color: var(--parsec-color-secondary-light);
   }
 }
 </style>

--- a/lib/components/ms-text/MsInformativeText.vue
+++ b/lib/components/ms-text/MsInformativeText.vue
@@ -32,13 +32,13 @@ defineProps<{
   max-width: 37.5rem;
 
   &__icon {
-    color: var(--parsec-color-light-primary-600);
+    color: var(--parsec-color-primary-600);
     font-size: 1.25rem;
     min-width: 1.25rem;
   }
 
   &__text {
-    color: var(--parsec-color-light-secondary-grey);
+    color: var(--parsec-color-secondary-grey);
   }
 }
 </style>

--- a/lib/components/ms-text/MsReportText.vue
+++ b/lib/components/ms-text/MsReportText.vue
@@ -43,23 +43,23 @@ function getIcon(): string {
 <style scoped lang="scss">
 @use '@lib/theme' as ms;
 .ms-info {
-  --ms-alert-text-background-color: var(--parsec-color-light-info-50);
-  --ms-alert-text-icon-color: var(--parsec-color-light-info-700);
+  --ms-alert-text-background-color: var(--parsec-color-info-50);
+  --ms-alert-text-icon-color: var(--parsec-color-info-700);
 }
 
 .ms-success {
-  --ms-alert-text-background-color: var(--parsec-color-light-success-50);
-  --ms-alert-text-icon-color: var(--parsec-color-light-success-700);
+  --ms-alert-text-background-color: var(--parsec-color-success-50);
+  --ms-alert-text-icon-color: var(--parsec-color-success-700);
 }
 
 .ms-warning {
-  --ms-alert-text-background-color: var(--parsec-color-light-warning-50);
-  --ms-alert-text-icon-color: var(--parsec-color-light-warning-700);
+  --ms-alert-text-background-color: var(--parsec-color-warning-50);
+  --ms-alert-text-icon-color: var(--parsec-color-warning-700);
 }
 
 .ms-error {
-  --ms-alert-text-background-color: var(--parsec-color-light-danger-50);
-  --ms-alert-text-icon-color: var(--parsec-color-light-danger-700);
+  --ms-alert-text-background-color: var(--parsec-color-danger-50);
+  --ms-alert-text-icon-color: var(--parsec-color-danger-700);
 }
 
 .container-textinfo {
@@ -81,7 +81,7 @@ function getIcon(): string {
   }
 
   &__text {
-    color: var(--parsec-color-light-secondary-text);
+    color: var(--parsec-color-secondary-text);
   }
   &.ms-info,
   &.ms-success,

--- a/lib/components/ms-textarea/MsTextarea.vue
+++ b/lib/components/ms-textarea/MsTextarea.vue
@@ -143,19 +143,19 @@ async function onChange(value: string): Promise<void> {
 
 <style scoped lang="scss">
 .textarea {
-  border: 1px solid var(--parsec-color-light-secondary-disabled);
+  border: 1px solid var(--parsec-color-secondary-disabled);
   border-radius: var(--parsec-radius-8);
-  color: var(--parsec-color-light-primary-800);
+  color: var(--parsec-color-primary-800);
   padding: 0.625rem 0.625rem 0;
 
   &:focus-within {
-    border: 1px solid var(--parsec-color-light-primary-400);
-    background: var(--parsec-color-light-secondary-white);
-    outline: 0.25rem solid var(--parsec-color-light-outline);
+    border: 1px solid var(--parsec-color-primary-400);
+    background: var(--parsec-color-secondary-surface);
+    outline: 0.25rem solid var(--parsec-color-outline);
   }
 
   &:hover {
-    border: 1px solid var(--parsec-color-light-primary-300);
+    border: 1px solid var(--parsec-color-primary-300);
   }
 }
 
@@ -164,15 +164,15 @@ async function onChange(value: string): Promise<void> {
   margin-left: auto;
 
   &-default {
-    color: var(--parsec-color-light-secondary-grey);
+    color: var(--parsec-color-secondary-grey);
   }
 
   &-warn {
-    color: var(--parsec-color-light-warning-500);
+    color: var(--parsec-color-warning-500);
   }
 
   &-full {
-    color: var(--parsec-color-light-danger-500);
+    color: var(--parsec-color-danger-500);
   }
 }
 </style>

--- a/lib/components/ms-toggle/MsBooleanToggle.vue
+++ b/lib/components/ms-toggle/MsBooleanToggle.vue
@@ -65,16 +65,16 @@ function setFocus(): void {
   display: flex;
   padding: 0.25rem;
   border-radius: 1.5rem;
-  border: 1px solid var(--parsec-color-light-secondary-disabled);
+  border: 1px solid var(--parsec-color-secondary-disabled);
   &:focus-within {
-    border: 1px solid var(--parsec-color-light-primary-400);
-    background: var(--parsec-color-light-secondary-white);
-    outline: 0.25rem solid var(--parsec-color-light-outline);
+    border: 1px solid var(--parsec-color-primary-400);
+    background: var(--parsec-color-secondary-surface);
+    outline: 0.25rem solid var(--parsec-color-outline);
   }
 }
 
 .button-view {
-  color: var(--parsec-color-light-secondary-grey);
+  color: var(--parsec-color-secondary-grey);
   padding: 0.125rem 1.5rem;
   border-radius: 1.5rem;
   position: relative;
@@ -87,13 +87,13 @@ function setFocus(): void {
     position: relative;
 
     &:hover {
-      background: var(--parsec-color-light-secondary-premiere);
+      background: var(--parsec-color-secondary-premiere);
     }
   }
 }
 
 .button-disabled {
-  background: var(--parsec-color-light-primary-50);
-  color: var(--parsec-color-light-primary-600);
+  background: var(--parsec-color-primary-50);
+  color: var(--parsec-color-primary-600);
 }
 </style>

--- a/lib/components/ms-toggle/MsGridListToggle.vue
+++ b/lib/components/ms-toggle/MsGridListToggle.vue
@@ -48,15 +48,15 @@ defineExpose({
   display: flex;
   align-items: center;
   border-radius: var(--parsec-radius-8);
-  border: 1px solid var(--parsec-color-light-secondary-medium);
-  background: var(--parsec-color-light-secondary-premiere);
+  border: 1px solid var(--parsec-color-secondary-medium);
+  background: var(--parsec-color-secondary-premiere);
   flex-shrink: 0;
   overflow: hidden;
   box-shadow: var(--parsec-shadow-low);
 }
 
 .button-view {
-  color: var(--parsec-color-light-secondary-light);
+  color: var(--parsec-color-secondary-light);
   min-height: 1rem;
   height: 100%;
   --ripple-color: transparent;
@@ -66,7 +66,7 @@ defineExpose({
     --background-hover: none;
 
     &:hover {
-      color: var(--parsec-color-light-secondary-soft-grey);
+      color: var(--parsec-color-secondary-soft-grey);
     }
   }
 
@@ -80,14 +80,14 @@ defineExpose({
   }
 
   &:nth-child(1) {
-    border-right: 1px solid var(--parsec-color-light-secondary-medium);
+    border-right: 1px solid var(--parsec-color-secondary-medium);
   }
 }
 
 // eslint-disable-next-line vue-scoped-css/no-unused-selector
 .button-disabled {
-  background: var(--parsec-color-light-secondary-white);
-  color: var(--parsec-color-light-secondary-hard-grey);
+  background: var(--parsec-color-secondary-surface);
+  color: var(--parsec-color-secondary-hard-grey);
   opacity: 1;
 }
 </style>

--- a/lib/components/ms-toggle/MsGridListToggle.vue
+++ b/lib/components/ms-toggle/MsGridListToggle.vue
@@ -48,7 +48,7 @@ defineExpose({
   display: flex;
   align-items: center;
   border-radius: var(--parsec-radius-10);
-  border: 1px solid var(--parsec-color-light-secondary-medium);
+  border: 1px solid var(--parsec-color-secondary-medium);
   padding: 0.25rem;
   background: var(--parsec-color-light-secondary-premiere);
   flex-shrink: 0;
@@ -56,7 +56,7 @@ defineExpose({
 }
 
 .button-view {
-  color: var(--parsec-color-light-secondary-light);
+  color: var(--parsec-color-secondary-light);
   min-height: 1rem;
   height: 100%;
   --ripple-color: transparent;
@@ -67,7 +67,7 @@ defineExpose({
     --background-hover: none;
 
     &:hover {
-      color: var(--parsec-color-light-secondary-soft-grey);
+      color: var(--parsec-color-secondary-soft-grey);
     }
   }
 
@@ -83,8 +83,8 @@ defineExpose({
 
 // eslint-disable-next-line vue-scoped-css/no-unused-selector
 .button-disabled {
-  background: var(--parsec-color-light-secondary-white);
-  color: var(--parsec-color-light-secondary-hard-grey);
+  background: var(--parsec-color-secondary-surface);
+  color: var(--parsec-color-secondary-hard-grey);
   opacity: 1;
   box-shadow:
     0 3px 5px 0 rgba(0, 0, 0, 0.02),

--- a/lib/components/ms-toggle/MsGridListToggle.vue
+++ b/lib/components/ms-toggle/MsGridListToggle.vue
@@ -50,7 +50,7 @@ defineExpose({
   border-radius: var(--parsec-radius-10);
   border: 1px solid var(--parsec-color-secondary-medium);
   padding: 0.25rem;
-  background: var(--parsec-color-light-secondary-premiere);
+  background: var(--parsec-color-secondary-premiere);
   flex-shrink: 0;
   overflow: hidden;
 }

--- a/lib/components/ms-tooltip/MsInformationTooltip.vue
+++ b/lib/components/ms-tooltip/MsInformationTooltip.vue
@@ -23,10 +23,10 @@ defineProps<{
 
 <style scoped lang="scss">
 .icon {
-  --color: var(--parsec-color-light-secondary-grey);
+  --color: var(--parsec-color-secondary-grey);
 
   &:hover {
-    color: var(--parsec-color-light-secondary-text);
+    color: var(--parsec-color-secondary-text);
   }
 }
 </style>

--- a/lib/components/ms-tooltip/MsTooltip.vue
+++ b/lib/components/ms-tooltip/MsTooltip.vue
@@ -26,7 +26,7 @@ defineProps<{
   display: flex;
   align-items: center;
   flex-direction: column;
-  --fill-color: var(--parsec-color-light-primary-900);
+  --fill-color: var(--parsec-color-primary-900);
 
   // &.bottom {
   //   flex-direction: column-reverse;
@@ -38,8 +38,8 @@ defineProps<{
 }
 
 .tooltip-content {
-  background: var(--parsec-color-light-primary-900);
-  color: var(--parsec-color-light-primary-30);
+  background: var(--parsec-color-primary-900);
+  color: var(--parsec-color-primary-30);
   max-width: 14.5rem;
   width: fit-content;
   padding: 0.375rem 0.5rem;

--- a/lib/theme/components/_buttons.scss
+++ b/lib/theme/components/_buttons.scss
@@ -52,41 +52,41 @@ ion-button.button-small {
 
 /* button default */
 ion-button:not(.button-outline):not(.button-clear) {
-  --background: var(--parsec-color-light-primary-500);
-  --background-hover: var(--parsec-color-light-primary-700);
+  --background: var(--parsec-color-primary-500);
+  --background-hover: var(--parsec-color-primary-700);
   --background-hover-opacity: none;
 }
 
 /* button outline */
 ion-button.button-outline {
-  --border-color: var(--parsec-color-light-primary-500);
+  --border-color: var(--parsec-color-primary-500);
   --border-width: 1px;
   --background: none;
-  --color: var(--parsec-color-light-primary-500);
-  --color-hover: var(--parsec-color-light-primary-600);
+  --color: var(--parsec-color-primary-500);
+  --color-hover: var(--parsec-color-primary-600);
   --background-hover: none;
   --background-hover-opacity: none;
 
   &:hover {
-    --border-color: var(--parsec-color-light-primary-600);
+    --border-color: var(--parsec-color-primary-600);
   }
 }
 
 /* ghost */
 .sc-ion-buttons-md-s .button-clear,
 .button-clear {
-  --color: var(--parsec-color-light-primary-500);
-  --color-hover: var(--parsec-color-light-primary-700);
-  --background-hover: var(--parsec-color-light-primary-50);
+  --color: var(--parsec-color-primary-500);
+  --color-hover: var(--parsec-color-primary-700);
+  --background-hover: var(--parsec-color-primary-50);
   --background-hover-opacity: none;
 }
 
 /* solid */
 ion-button.button-solid {
-  --background: var(--parsec-color-light-primary-100);
+  --background: var(--parsec-color-primary-100);
 }
 
 .danger {
-  color: var(--parsec-color-light-danger-500);
-  --background-hover: var(--parsec-color-light-danger-100) !important;
+  color: var(--parsec-color-danger-500);
+  --background-hover: var(--parsec-color-danger-100) !important;
 }

--- a/lib/theme/components/_buttons.scss
+++ b/lib/theme/components/_buttons.scss
@@ -56,41 +56,41 @@ ion-button.button-small {
 
 /* button default */
 ion-button:not(.button-outline):not(.button-clear) {
-  --background: var(--parsec-color-light-primary-500);
-  --background-hover: var(--parsec-color-light-primary-700);
+  --background: var(--parsec-color-primary-500);
+  --background-hover: var(--parsec-color-primary-700);
   --background-hover-opacity: none;
 }
 
 /* button outline */
 ion-button.button-outline {
-  --border-color: var(--parsec-color-light-primary-500);
+  --border-color: var(--parsec-color-primary-500);
   --border-width: 1px;
   --background: none;
-  --color: var(--parsec-color-light-primary-500);
-  --color-hover: var(--parsec-color-light-primary-600);
+  --color: var(--parsec-color-primary-500);
+  --color-hover: var(--parsec-color-primary-600);
   --background-hover: none;
   --background-hover-opacity: none;
 
   &:hover {
-    --border-color: var(--parsec-color-light-primary-600);
+    --border-color: var(--parsec-color-primary-600);
   }
 }
 
 /* ghost */
 .sc-ion-buttons-md-s .button-clear,
 .button-clear {
-  --color: var(--parsec-color-light-primary-500);
-  --color-hover: var(--parsec-color-light-primary-700);
-  --background-hover: var(--parsec-color-light-primary-50);
+  --color: var(--parsec-color-primary-500);
+  --color-hover: var(--parsec-color-primary-700);
+  --background-hover: var(--parsec-color-primary-50);
   --background-hover-opacity: none;
 }
 
 /* solid */
 ion-button.button-solid {
-  --background: var(--parsec-color-light-primary-100);
+  --background: var(--parsec-color-primary-100);
 }
 
 .danger {
-  color: var(--parsec-color-light-danger-500);
-  --background-hover: var(--parsec-color-light-danger-100) !important;
+  color: var(--parsec-color-danger-500);
+  --background-hover: var(--parsec-color-danger-100) !important;
 }

--- a/lib/theme/components/_inputs.scss
+++ b/lib/theme/components/_inputs.scss
@@ -16,11 +16,11 @@
 
 // label
 .form-label {
-  color: var(--parsec-color-light-secondary-hard-grey);
+  color: var(--parsec-color-secondary-hard-grey);
   cursor: pointer;
 
   &.focused {
-    color: var(--parsec-color-light-primary-700);
+    color: var(--parsec-color-primary-700);
   }
 }
 
@@ -31,23 +31,23 @@
   flex-grow: 1;
   width: auto;
   padding: 0 0.75rem;
-  border: 1px solid var(--parsec-color-light-secondary-disabled);
+  border: 1px solid var(--parsec-color-secondary-disabled);
   box-shadow: var(--parsec-shadow-input);
   border-radius: var(--parsec-radius-8);
-  color: var(--parsec-color-light-primary-800);
+  color: var(--parsec-color-primary-800);
   transition: outline 0.2s ease-in-out;
   position: relative;
   height: 2.75rem;
 
   &:hover:not(.form-input-disabled),
   &:hover:not(.input-invalid) {
-    border: 1px solid var(--parsec-color-light-primary-300);
+    border: 1px solid var(--parsec-color-primary-300);
   }
 
   &:focus-within:not(.form-input-disabled) {
-    border: 1px solid var(--parsec-color-light-primary-400);
-    background: var(--parsec-color-light-secondary-white);
-    outline: 0.25rem solid var(--parsec-color-light-outline);
+    border: 1px solid var(--parsec-color-primary-400);
+    background: var(--parsec-color-secondary-surface);
+    outline: 0.25rem solid var(--parsec-color-outline);
   }
 }
 
@@ -60,7 +60,7 @@
   height: 100%;
   flex-grow: 1;
   --border-width: 0;
-  --placeholder-color: var(--parsec-color-light-secondary-grey);
+  --placeholder-color: var(--parsec-color-secondary-grey);
   --highlight-color: none;
   --highlight-color-focused: none;
   --padding-top: 0;
@@ -77,7 +77,7 @@
 
   &-disabled {
     opacity: 1 !important;
-    color: var(--parsec-color-light-secondary-hard-grey);
+    color: var(--parsec-color-secondary-hard-grey);
     --placeholder-opacity: 1;
   }
 
@@ -87,44 +87,44 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--parsec-color-light-secondary-grey);
+    color: var(--parsec-color-secondary-grey);
     font-size: 1.125rem;
 
     &:hover {
       border-radius: var(--parsec-radius-6);
-      color: var(--parsec-color-light-primary-700);
+      color: var(--parsec-color-primary-700);
     }
   }
 
   &-clear-icon {
     margin-inline-end: 0.55rem !important;
-    color: var(--parsec-color-light-secondary-grey) !important;
+    color: var(--parsec-color-secondary-grey) !important;
   }
 
   // valid input
   &-valid {
-    border: 1px solid var(--parsec-color-light-primary-300);
+    border: 1px solid var(--parsec-color-primary-300);
 
     &:not(:focus-within) {
-      border: 1px solid var(--parsec-color-light-success-500);
+      border: 1px solid var(--parsec-color-success-500);
     }
   }
 
   // invalid input
   &-invalid {
-    border: 1px solid var(--parsec-color-light-danger-500);
+    border: 1px solid var(--parsec-color-danger-500);
     transition: outline 0.2s ease-in-out;
 
     &:focus-within {
-      outline: 0.5px solid var(--parsec-color-light-danger-500);
-      border: 1px solid var(--parsec-color-light-danger-500);
+      outline: 0.5px solid var(--parsec-color-danger-500);
+      border: 1px solid var(--parsec-color-danger-500);
     }
   }
 }
 
 .form-input-disabled {
-  --background: var(--parsec-color-light-secondary-medium);
-  background: var(--parsec-color-light-secondary-medium);
+  --background: var(--parsec-color-secondary-medium);
+  background: var(--parsec-color-secondary-medium);
   border: 1px solid transparent;
 }
 
@@ -134,7 +134,7 @@
 
 // error message
 .form-error {
-  color: var(--parsec-color-light-danger-500);
+  color: var(--parsec-color-danger-500);
   display: flex;
   align-items: center;
   gap: 0.2rem;
@@ -142,20 +142,20 @@
 
 .datetime-picker {
   .dp__theme_light {
-    --dp-primary-color: var(--parsec-color-light-primary-500);
-    --dp-secondary-color: var(--parsec-color-light-secondary-light);
-    --dp-text-color: var(--parsec-color-light-primary-800);
-    --dp-background-color: var(--parsec-color-light-secondary-white);
-    --dp-border-color: var(--parsec-color-light-secondary-light);
+    --dp-primary-color: var(--parsec-color-primary-500);
+    --dp-secondary-color: var(--parsec-color-secondary-light);
+    --dp-text-color: var(--parsec-color-primary-800);
+    --dp-background-color: var(--parsec-color-secondary-surface);
+    --dp-border-color: var(--parsec-color-secondary-light);
     --dp-font-family: 'Albert Sans', Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   }
 
   .dp__input {
-    border-color: var(--parsec-color-light-secondary-light);
+    border-color: var(--parsec-color-secondary-light);
     font-family: 'Albert Sans', Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
     font-size: 0.875rem;
     border-radius: var(--parsec-radius-8);
-    --dp-border-color-hover: var(--parsec-color-light-primary-300);
+    --dp-border-color-hover: var(--parsec-color-primary-300);
     transition: all 0.2s ease-in-out;
   }
 
@@ -176,7 +176,7 @@
 
     .dp__selection_preview {
       font-size: 0.875rem;
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
 
     .dp__action_buttons {
@@ -199,15 +199,15 @@
       }
 
       &:hover {
-        background: var(--parsec-color-light-primary-600);
+        background: var(--parsec-color-primary-600);
       }
     }
   }
 
   &:has(.dp--menu-wrapper) {
     .dp__input {
-      border: 1px solid var(--parsec-color-light-primary-300);
-      outline: 0.25rem solid var(--parsec-color-light-outline);
+      border: 1px solid var(--parsec-color-primary-300);
+      outline: 0.25rem solid var(--parsec-color-outline);
     }
   }
 }

--- a/lib/theme/components/_modals.scss
+++ b/lib/theme/components/_modals.scss
@@ -134,7 +134,7 @@ ion-modal .inner-content {
   // manage the handle
   &::part(handle) {
     margin: 0.5rem auto;
-    background: var(--parsec-color-light-secondary-light);
+    background: var(--parsec-color-secondary-light);
   }
 }
 
@@ -151,8 +151,8 @@ ion-modal .inner-content {
   z-index: 1000;
 
   &::part(native) {
-    background: var(--parsec-color-light-secondary-white);
-    --background-hover: var(--parsec-color-light-secondary-medium);
+    background: var(--parsec-color-secondary-surface);
+    --background-hover: var(--parsec-color-secondary-medium);
     padding: 0.125rem;
     height: 2rem;
   }
@@ -164,17 +164,17 @@ ion-modal .inner-content {
 
   &__icon {
     font-size: 1.75rem;
-    color: var(--parsec-color-light-secondary-grey);
+    color: var(--parsec-color-secondary-grey);
   }
 
   &:active {
-    --background: var(--parsec-color-light-secondary-medium);
+    --background: var(--parsec-color-secondary-medium);
     --border-radius: var(--parsec-radius-6);
   }
 
   &:hover {
     ion-icon {
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
   }
 }
@@ -208,6 +208,6 @@ ion-modal .inner-content {
     }
   }
   .spinner-label__text {
-    color: var(--parsec-color-light-secondary-soft-text);
+    color: var(--parsec-color-secondary-soft-text);
   }
 }

--- a/lib/theme/components/_modals.scss
+++ b/lib/theme/components/_modals.scss
@@ -140,7 +140,7 @@ ion-modal .inner-content {
   // manage the handle
   &::part(handle) {
     margin: 0.5rem auto;
-    background: var(--parsec-color-light-secondary-light);
+    background: var(--parsec-color-secondary-light);
   }
 }
 
@@ -157,8 +157,8 @@ ion-modal .inner-content {
   z-index: 1000;
 
   &::part(native) {
-    background: var(--parsec-color-light-secondary-white);
-    --background-hover: var(--parsec-color-light-secondary-medium);
+    background: var(--parsec-color-secondary-surface);
+    --background-hover: var(--parsec-color-secondary-medium);
     padding: 0.125rem;
     height: 2rem;
   }
@@ -170,17 +170,17 @@ ion-modal .inner-content {
 
   &__icon {
     font-size: 1.75rem;
-    color: var(--parsec-color-light-secondary-grey);
+    color: var(--parsec-color-secondary-grey);
   }
 
   &:active {
-    --background: var(--parsec-color-light-secondary-medium);
+    --background: var(--parsec-color-secondary-medium);
     --border-radius: var(--parsec-radius-6);
   }
 
   &:hover {
     ion-icon {
-      color: var(--parsec-color-light-secondary-text);
+      color: var(--parsec-color-secondary-text);
     }
   }
 }
@@ -214,7 +214,7 @@ ion-modal .inner-content {
     }
   }
   .spinner-label__text {
-    color: var(--parsec-color-light-secondary-soft-text);
+    color: var(--parsec-color-secondary-soft-text);
   }
 }
 

--- a/lib/theme/components/_modals.scss
+++ b/lib/theme/components/_modals.scss
@@ -221,32 +221,32 @@ ion-modal .inner-content {
 /* Theme color definitions */
 .small-display-modal.ms-info,
 .modal.ms-info {
-  --ms-modal-button-background-color: var(--parsec-color-light-primary-500);
-  --ms-modal-button-background-hover-color: var(--parsec-color-light-primary-600);
+  --ms-modal-button-background-color: var(--parsec-color-primary-500);
+  --ms-modal-button-background-hover-color: var(--parsec-color-primary-600);
 }
 
 .small-display-modal.ms-success,
 .modal.ms-success {
-  --ms-modal-button-background-color: var(--parsec-color-light-success-500);
-  --ms-modal-button-background-hover-color: var(--parsec-color-light-success-700);
+  --ms-modal-button-background-color: var(--parsec-color-success-500);
+  --ms-modal-button-background-hover-color: var(--parsec-color-success-700);
 }
 
 .small-display-modal.ms-warning,
 .modal.ms-warning {
-  --ms-modal-button-background-color: var(--parsec-color-light-warning-500);
-  --ms-modal-button-background-hover-color: var(--parsec-color-light-warning-700);
+  --ms-modal-button-background-color: var(--parsec-color-warning-500);
+  --ms-modal-button-background-hover-color: var(--parsec-color-warning-700);
 }
 
 .small-display-modal.ms-error,
 .modal.ms-error {
-  --ms-modal-button-background-color: var(--parsec-color-light-danger-500);
-  --ms-modal-button-background-hover-color: var(--parsec-color-light-danger-700);
+  --ms-modal-button-background-color: var(--parsec-color-danger-500);
+  --ms-modal-button-background-hover-color: var(--parsec-color-danger-700);
 }
 
 .small-display-modal.ms-light,
 .modal.ms-light {
-  --ms-modal-button-background-color: var(--parsec-color-light-secondary-text);
-  --ms-modal-button-background-hover-color: var(--parsec-color-light-secondary-contrast);
+  --ms-modal-button-background-color: var(--parsec-color-secondary-text);
+  --ms-modal-button-background-hover-color: var(--parsec-color-secondary-contrast);
 }
 
 .modal.ms-info,
@@ -270,12 +270,12 @@ ion-modal .inner-content {
     margin-top: 0;
 
     #cancel-button {
-      --background: var(--parsec-color-light-secondary-white) !important;
-      --color: var(--parsec-color-light-secondary-soft-text) !important;
+      --background: var(--parsec-color-secondary-surface) !important;
+      --color: var(--parsec-color-secondary-soft-text) !important;
 
       &::part(native) {
-        --background-hover: var(--parsec-color-light-secondary-premiere) !important;
-        border: 1px solid var(--parsec-color-light-secondary-medium);
+        --background-hover: var(--parsec-color-secondary-premiere) !important;
+        border: 1px solid var(--parsec-color-secondary-medium);
       }
     }
 

--- a/lib/theme/components/_scrollbars.scss
+++ b/lib/theme/components/_scrollbars.scss
@@ -3,7 +3,7 @@
 /* **** Parsec scrollbar **** */
 
 body {
-  scrollbar-color: var(--parsec-color-light-scrollbar-thumb) var(--parsec-color-light-scrollbar-track);
+  scrollbar-color: var(--parsec-color-scrollbar-thumb) var(--parsec-color-scrollbar-track);
   scrollbar-width: thin;
   scrollbar-gutter: stable;
 }
@@ -15,14 +15,14 @@ body {
 
 ::-webkit-scrollbar-thumb {
   border-radius: 1em;
-  background-color: var(--parsec-color-light-scrollbar-thumb);
+  background-color: var(--parsec-color-scrollbar-thumb);
   background-clip: content-box;
-  border: 0.25rem solid var(--parsec-color-light-scrollbar-track);
+  border: 0.25rem solid var(--parsec-color-scrollbar-track);
 
   &:hover {
-    background-color: var(--parsec-color-light-scrollbar-thumb-hover);
+    background-color: var(--parsec-color-scrollbar-thumb-hover);
   }
 }
 ::-webkit-scrollbar-track {
-  background-color: var(--parsec-color-light-scrollbar-track);
+  background-color: var(--parsec-color-scrollbar-track);
 }

--- a/lib/theme/components/_toasts.scss
+++ b/lib/theme/components/_toasts.scss
@@ -21,31 +21,31 @@ ion-toast.notification-toast {
   }
 
   &.ms-info {
-    --ms-notification-toast-text-color: var(--parsec-color-light-info-700);
-    --ms-notification-toast-border-color: var(--parsec-color-light-info-500);
-    --ms-notification-toast-progress-bg-color: var(--parsec-color-light-info-100);
-    --ms-notification-toast-progress-color: var(--parsec-color-light-info-500);
+    --ms-notification-toast-text-color: var(--parsec-color-info-700);
+    --ms-notification-toast-border-color: var(--parsec-color-info-500);
+    --ms-notification-toast-progress-bg-color: var(--parsec-color-info-100);
+    --ms-notification-toast-progress-color: var(--parsec-color-info-500);
   }
 
   &.ms-success {
-    --ms-notification-toast-text-color: var(--parsec-color-light-success-700);
-    --ms-notification-toast-border-color: var(--parsec-color-light-success-500);
-    --ms-notification-toast-progress-bg-color: var(--parsec-color-light-success-100);
-    --ms-notification-toast-progress-color: var(--parsec-color-light-success-500);
+    --ms-notification-toast-text-color: var(--parsec-color-success-700);
+    --ms-notification-toast-border-color: var(--parsec-color-success-500);
+    --ms-notification-toast-progress-bg-color: var(--parsec-color-success-100);
+    --ms-notification-toast-progress-color: var(--parsec-color-success-500);
   }
 
   &.ms-warning {
-    --ms-notification-toast-text-color: var(--parsec-color-light-warning-700);
-    --ms-notification-toast-border-color: var(--parsec-color-light-warning-500);
-    --ms-notification-toast-progress-bg-color: var(--parsec-color-light-warning-100);
-    --ms-notification-toast-progress-color: var(--parsec-color-light-warning-500);
+    --ms-notification-toast-text-color: var(--parsec-color-warning-700);
+    --ms-notification-toast-border-color: var(--parsec-color-warning-500);
+    --ms-notification-toast-progress-bg-color: var(--parsec-color-warning-100);
+    --ms-notification-toast-progress-color: var(--parsec-color-warning-500);
   }
 
   &.ms-error {
-    --ms-notification-toast-text-color: var(--parsec-color-light-danger-700);
-    --ms-notification-toast-border-color: var(--parsec-color-light-danger-500);
-    --ms-notification-toast-progress-bg-color: var(--parsec-color-light-danger-100);
-    --ms-notification-toast-progress-color: var(--parsec-color-light-danger-500);
+    --ms-notification-toast-text-color: var(--parsec-color-danger-700);
+    --ms-notification-toast-border-color: var(--parsec-color-danger-500);
+    --ms-notification-toast-progress-bg-color: var(--parsec-color-danger-100);
+    --ms-notification-toast-progress-color: var(--parsec-color-danger-500);
   }
 
   &.ms-info,
@@ -53,16 +53,16 @@ ion-toast.notification-toast {
   &.ms-warning,
   &.ms-error {
     &::part(container) {
-      --background: var(--parsec-color-light-secondary-background);
+      --background: var(--parsec-color-secondary-background);
       --border-color: var(--ms-notification-toast-border-color);
       --border-radius: var(--parsec-radius-12);
-      --button-color: var(--parsec-color-light-secondary-text);
+      --button-color: var(--parsec-color-secondary-text);
       color: var(--ms-notification-toast-text-color);
     }
   }
 
   &::part(container) {
-    background-color: var(--parsec-color-light-secondary-inversed-contrast);
+    background-color: var(--parsec-color-secondary-inversed-contrast);
     border-radius: var(--parsec-radius-12);
     overflow: hidden;
     max-width: 27rem;
@@ -107,7 +107,7 @@ ion-toast.notification-toast {
   }
 
   &::part(message) {
-    color: var(--parsec-color-light-secondary-text);
+    color: var(--parsec-color-secondary-text);
   }
 
   &::part(icon) {
@@ -115,11 +115,11 @@ ion-toast.notification-toast {
     padding: 0.25rem;
     background: var(--ms-notification-toast-text-color);
     border-radius: var(--parsec-radius-8);
-    color: var(--parsec-color-light-secondary-inversed-contrast);
+    color: var(--parsec-color-secondary-inversed-contrast);
   }
 
   &::part(button) {
-    background: var(--parsec-color-light-secondary-background);
+    background: var(--parsec-color-secondary-background);
     padding: 0.375rem 0.75rem;
     font-size: 0.875rem;
     min-height: 0;

--- a/lib/theme/components/_toggles.scss
+++ b/lib/theme/components/_toggles.scss
@@ -14,49 +14,49 @@ ion-toggle {
     height: 28px;
     width: 50px;
     border-radius: var(--parsec-radius-32);
-    background: var(--parsec-color-light-secondary-light);
+    background: var(--parsec-color-secondary-light);
     /* Required for iOS handle to overflow the height of the track */
     overflow: visible;
     opacity: 0.4;
   }
 
   &::part(handle) {
-    background: var(--parsec-color-light-secondary-white);
+    background: var(--parsec-color-secondary-surface);
     box-shadow: none;
   }
 
   // check
   &.toggle-checked::part(track) {
-    background: var(--parsec-color-light-primary-600);
+    background: var(--parsec-color-primary-600);
     border: none;
     opacity: 1;
   }
 
   &.toggle-checked::part(handle) {
-    background: var(--parsec-color-light-secondary-inversed-contrast);
+    background: var(--parsec-color-secondary-inversed-contrast);
     box-shadow: var(--parsec-shadow-toggle);
   }
 
   &.dark {
     &::part(track) {
-      background: var(--parsec-color-light-secondary-inversed-contrast);
-      box-shadow: inset 0px 0px 0px 1px var(--parsec-color-light-secondary-inversed-contrast);
+      background: var(--parsec-color-secondary-inversed-contrast);
+      box-shadow: inset 0px 0px 0px 1px var(--parsec-color-secondary-inversed-contrast);
     }
 
     &::part(handle) {
-      background: var(--parsec-color-light-primary-700);
+      background: var(--parsec-color-primary-700);
     }
 
     // check
     &.toggle-checked::part(track) {
-      box-shadow: inset 0px 0px 0px 1px var(--parsec-color-light-primary-100);
-      background: var(--parsec-color-light-primary-100);
+      box-shadow: inset 0px 0px 0px 1px var(--parsec-color-primary-100);
+      background: var(--parsec-color-primary-100);
       border: none;
       opacity: 1;
     }
 
     &.toggle-checked::part(handle) {
-      background: var(--parsec-color-light-primary-800);
+      background: var(--parsec-color-primary-800);
       box-shadow: var(--parsec-shadow-toggle);
     }
   }

--- a/lib/theme/global.scss
+++ b/lib/theme/global.scss
@@ -3,13 +3,8 @@
 /* Ionic Variables and Theming. For more info, please see:
 http://ionicframework.com/docs/theming/ */
 
-// Ionic imports
 @use 'ionic' as ionic;
-
-// import variables
 @use 'variables' as variables;
-
-// import components
 @use 'components' as components;
 
 /**** Global CSS overloads ****/
@@ -65,7 +60,7 @@ ion-checkbox {
 
 a {
   text-decoration: none;
-  color: var(--parsec-color-light-primary-500);
+  color: var(--parsec-color-primary-500);
 }
 
 svg {

--- a/lib/theme/variables/_colors-light.scss
+++ b/lib/theme/variables/_colors-light.scss
@@ -1,0 +1,81 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+/**** Parsec light theme colors ****/
+:root {
+  /* gradient */
+  --parsec-color-light-gradient: linear-gradient(113.02deg, #4092ff -1.49%, #0058cc 100%);
+  --parsec-color-light-gradient-background: linear-gradient(
+    113deg,
+    var(--parsec-color-light-primary-500) -1.49%,
+    var(--parsec-color-light-primary-600) 100%
+  );
+
+  /* Outline */
+  --parsec-color-light-outline: rgba(102, 168, 255, 0.25);
+
+  /* Primary */
+  --parsec-color-light-primary-30-opacity15: hsla(212, 100%, 97.1%, 0.15);
+  --parsec-color-light-primary-30: hsla(212, 100%, 97%, 1);
+  --parsec-color-light-primary-50: hsla(212, 100%, 95%, 1);
+  --parsec-color-light-primary-100: hsla(214, 100%, 90%, 1);
+  --parsec-color-light-primary-200: hsla(214, 100%, 80%, 1);
+  --parsec-color-light-primary-300: hsla(214, 100%, 70%, 1);
+  --parsec-color-light-primary-400: hsla(214, 100%, 60%, 1);
+  --parsec-color-light-primary-500: hsla(214, 100%, 50%, 1);
+  --parsec-color-light-primary-600: hsla(214, 100%, 40%, 1);
+  --parsec-color-light-primary-700: hsla(214, 100%, 30%, 1);
+  --parsec-color-light-primary-800: hsla(214, 100%, 20%, 1);
+  --parsec-color-light-primary-900: hsla(214, 100%, 10%, 1);
+
+  /* Secondary */
+  --parsec-color-light-secondary-opacity30: hsla(0, 0%, 100%, 0.3);
+  --parsec-color-light-secondary-black: hsla(240, 20%, 13%, 1);
+  --parsec-color-light-secondary-contrast: hsla(240, 20%, 20%, 1);
+  --parsec-color-light-secondary-text: hsla(240, 20%, 30%, 1);
+  --parsec-color-light-secondary-soft-text: hsla(240, 20%, 40%, 1);
+  --parsec-color-light-secondary-hard-grey: hsla(240, 20%, 50%, 1);
+  --parsec-color-light-secondary-grey: hsla(240, 20%, 60%, 1);
+  --parsec-color-light-secondary-soft-grey: hsla(240, 20%, 70%, 1);
+  --parsec-color-light-secondary-light: hsla(240, 20%, 80%, 1);
+  --parsec-color-light-secondary-disabled: hsla(240, 20%, 90%, 1);
+  --parsec-color-light-secondary-medium: hsla(240, 20%, 93%, 1);
+  --parsec-color-light-secondary-premiere: hsla(240, 20%, 96%, 1);
+  --parsec-color-light-secondary-background: hsla(240, 20%, 98%, 1);
+  --parsec-color-light-secondary-inversed-contrast: hsla(0, 0%, 99%, 1);
+  --parsec-color-light-secondary-white: hsl(0, 0%, 100%);
+  --parsec-color-light-secondary-surface: hsl(0, 0%, 100%);
+
+  /* ------ alerts light ------ */
+  --parsec-color-light-info-50: hsla(212, 60%, 95%, 1);
+  --parsec-color-light-info-100: hsla(212, 92%, 90%, 1);
+  --parsec-color-light-info-500: hsla(212, 60%, 50%, 1);
+  --parsec-color-light-info-700: hsla(212, 90%, 30%, 1);
+
+  --parsec-color-light-success-50: hsla(146, 60%, 95%, 1);
+  --parsec-color-light-success-100: hsla(146, 92%, 90%, 1);
+  --parsec-color-light-success-500: hsla(144, 60%, 50%, 1);
+  --parsec-color-light-success-700: hsla(144, 90%, 30%, 1);
+
+  --parsec-color-light-warning-50: hsla(45, 60%, 95%, 1);
+  --parsec-color-light-warning-100: hsla(45, 92%, 90%, 1);
+  --parsec-color-light-warning-500: hsla(45, 60%, 50%, 1);
+  --parsec-color-light-warning-700: hsla(45, 90%, 30%, 1);
+
+  --parsec-color-light-danger-50: hsla(352, 60%, 95%, 1);
+  --parsec-color-light-danger-100: hsla(352, 92%, 90%, 1);
+  --parsec-color-light-danger-500: hsla(352, 60%, 50%, 1);
+  --parsec-color-light-danger-700: hsla(352, 90%, 30%, 1);
+
+  /* ------ tags light ------ */
+  --parsec-color-light-tags-indigo-50: hsla(247, 100%, 95%, 1);
+  --parsec-color-light-tags-indigo-700: hsla(247, 100%, 30%, 1);
+  --parsec-color-light-tags-blue-50: var(--parsec-color-light-primary-50);
+  --parsec-color-light-tags-blue-700: var(--parsec-color-light-primary-700);
+  --parsec-color-light-tags-orange-50: hsla(28, 100%, 95%, 1);
+  --parsec-color-light-tags-orange-700: hsla(28, 100%, 30%, 1);
+
+  /* ------ scrollbar light ------ */
+  --parsec-color-light-scrollbar-thumb: hsl(240, 5%, 74%);
+  --parsec-color-light-scrollbar-thumb-hover: hsl(240, 5%, 55%);
+  --parsec-color-light-scrollbar-track: hsla(0, 0%, 100%, 0);
+}

--- a/lib/theme/variables/_colors-light.scss
+++ b/lib/theme/variables/_colors-light.scss
@@ -3,7 +3,7 @@
 /**** Parsec light theme colors ****/
 :root {
   /* gradient */
-  --parsec-color-light-gradient: linear-gradient(113.02deg, #4092ff -1.49%, #0058cc 100%);
+  --parsec-color-light-gradient: linear-gradient(113.02deg, hsl(214, 100%, 50%) -1.49%, hsl(214, 100%, 40%) 100%);
   --parsec-color-light-gradient-background: linear-gradient(
     113deg,
     var(--parsec-color-light-primary-500) -1.49%,
@@ -11,70 +11,69 @@
   );
 
   /* Outline */
-  --parsec-color-light-outline: rgba(102, 168, 255, 0.25);
+  --parsec-color-light-outline: hsla(214, 100%, 50%, 0.25);
 
-  /* Primary */
-  --parsec-color-light-primary-30-opacity15: hsla(212, 100%, 97.1%, 0.15);
-  --parsec-color-light-primary-30: hsla(212, 100%, 97%, 1);
-  --parsec-color-light-primary-50: hsla(212, 100%, 95%, 1);
-  --parsec-color-light-primary-100: hsla(214, 100%, 90%, 1);
-  --parsec-color-light-primary-200: hsla(214, 100%, 80%, 1);
-  --parsec-color-light-primary-300: hsla(214, 100%, 70%, 1);
-  --parsec-color-light-primary-400: hsla(214, 100%, 60%, 1);
-  --parsec-color-light-primary-500: hsla(214, 100%, 50%, 1);
-  --parsec-color-light-primary-600: hsla(214, 100%, 40%, 1);
-  --parsec-color-light-primary-700: hsla(214, 100%, 30%, 1);
-  --parsec-color-light-primary-800: hsla(214, 100%, 20%, 1);
-  --parsec-color-light-primary-900: hsla(214, 100%, 10%, 1);
+  /* Primary (root/color/brand) */
+  --parsec-color-light-primary-30-opacity15: hsla(214, 100%, 97%, 0.15);
+  --parsec-color-light-primary-30: hsl(214, 100%, 97%);
+  --parsec-color-light-primary-50: hsl(214, 100%, 94%);
+  --parsec-color-light-primary-100: hsl(214, 100%, 91%);
+  --parsec-color-light-primary-200: hsl(214, 100%, 84%);
+  --parsec-color-light-primary-300: hsl(214, 100%, 70%);
+  --parsec-color-light-primary-400: hsl(214, 100%, 60%);
+  --parsec-color-light-primary-500: hsl(214, 100%, 50%);
+  --parsec-color-light-primary-600: hsl(214, 100%, 40%);
+  --parsec-color-light-primary-700: hsl(214, 100%, 30%);
+  --parsec-color-light-primary-800: hsl(214, 100%, 20%);
+  --parsec-color-light-primary-900: hsl(214, 100%, 10%);
 
-  /* Secondary */
+  /* Secondary (root/color/grey) */
   --parsec-color-light-secondary-opacity30: hsla(0, 0%, 100%, 0.3);
-  --parsec-color-light-secondary-black: hsla(240, 20%, 13%, 1);
-  --parsec-color-light-secondary-contrast: hsla(240, 20%, 20%, 1);
-  --parsec-color-light-secondary-text: hsla(240, 20%, 30%, 1);
-  --parsec-color-light-secondary-soft-text: hsla(240, 20%, 40%, 1);
-  --parsec-color-light-secondary-hard-grey: hsla(240, 20%, 50%, 1);
-  --parsec-color-light-secondary-grey: hsla(240, 20%, 60%, 1);
-  --parsec-color-light-secondary-soft-grey: hsla(240, 20%, 70%, 1);
-  --parsec-color-light-secondary-light: hsla(240, 20%, 80%, 1);
-  --parsec-color-light-secondary-disabled: hsla(240, 20%, 90%, 1);
-  --parsec-color-light-secondary-medium: hsla(240, 20%, 93%, 1);
-  --parsec-color-light-secondary-premiere: hsla(240, 20%, 96%, 1);
-  --parsec-color-light-secondary-background: hsla(240, 20%, 98%, 1);
-  --parsec-color-light-secondary-inversed-contrast: hsla(0, 0%, 99%, 1);
+  --parsec-color-light-secondary-black: hsl(240, 22%, 12%);
+  --parsec-color-light-secondary-contrast: hsl(240, 20%, 17%);
+  --parsec-color-light-secondary-text: hsl(240, 20%, 27%);
+  --parsec-color-light-secondary-soft-text: hsl(240, 21%, 34%);
+  --parsec-color-light-secondary-hard-grey: hsl(240, 20%, 46%);
+  --parsec-color-light-secondary-grey: hsl(240, 20%, 60%);
+  --parsec-color-light-secondary-soft-grey: hsl(240, 20%, 75%);
+  --parsec-color-light-secondary-light: hsl(240, 20%, 84%);
+  --parsec-color-light-secondary-disabled: hsl(240, 22%, 90%);
+  --parsec-color-light-secondary-medium: hsl(240, 20%, 93%);
+  --parsec-color-light-secondary-premiere: hsl(240, 20%, 94%);
+  --parsec-color-light-secondary-background: hsl(240, 20%, 97%);
+  --parsec-color-light-secondary-inversed-contrast: hsl(240, 20%, 99%);
   --parsec-color-light-secondary-white: hsl(0, 0%, 100%);
   --parsec-color-light-secondary-surface: hsl(0, 0%, 100%);
 
   /* ------ alerts light ------ */
-  --parsec-color-light-info-50: hsla(212, 60%, 95%, 1);
-  --parsec-color-light-info-100: hsla(212, 92%, 90%, 1);
-  --parsec-color-light-info-500: hsla(212, 60%, 50%, 1);
-  --parsec-color-light-info-700: hsla(212, 90%, 30%, 1);
+  --parsec-color-light-info-50: hsl(212, 87%, 94%);
+  --parsec-color-light-info-100: hsl(212, 91%, 91%);
+  --parsec-color-light-info-500: hsl(212, 90%, 45%);
+  --parsec-color-light-info-700: hsl(212, 90%, 30%);
 
-  --parsec-color-light-success-50: hsla(146, 60%, 95%, 1);
-  --parsec-color-light-success-100: hsla(146, 92%, 90%, 1);
-  --parsec-color-light-success-500: hsla(144, 60%, 50%, 1);
-  --parsec-color-light-success-700: hsla(144, 90%, 30%, 1);
+  --parsec-color-light-success-50: hsl(144, 61%, 94%);
+  --parsec-color-light-success-100: hsl(144, 61%, 91%);
+  --parsec-color-light-success-500: hsl(144, 60%, 45%);
+  --parsec-color-light-success-700: hsl(144, 62%, 30%);
 
-  --parsec-color-light-warning-50: hsla(45, 60%, 95%, 1);
-  --parsec-color-light-warning-100: hsla(45, 92%, 90%, 1);
-  --parsec-color-light-warning-500: hsla(45, 60%, 50%, 1);
-  --parsec-color-light-warning-700: hsla(45, 90%, 30%, 1);
+  --parsec-color-light-warning-50: hsl(46, 93%, 94%);
+  --parsec-color-light-warning-100: hsl(46, 91%, 91%);
+  --parsec-color-light-warning-500: hsl(46, 60%, 45%);
+  --parsec-color-light-warning-700: hsl(46, 90%, 30%);
 
-  --parsec-color-light-danger-50: hsla(352, 60%, 95%, 1);
-  --parsec-color-light-danger-100: hsla(352, 92%, 90%, 1);
-  --parsec-color-light-danger-500: hsla(352, 60%, 50%, 1);
-  --parsec-color-light-danger-700: hsla(352, 90%, 30%, 1);
+  --parsec-color-light-danger-50: hsl(353, 60%, 94%);
+  --parsec-color-light-danger-100: hsl(351, 61%, 91%);
+  --parsec-color-light-danger-500: hsl(352, 60%, 45%);
+  --parsec-color-light-danger-700: hsl(353, 90%, 30%);
 
   /* ------ tags light ------ */
-  --parsec-color-light-tags-indigo-50: hsla(247, 100%, 95%, 1);
-  --parsec-color-light-tags-indigo-700: hsla(247, 100%, 30%, 1);
+  --parsec-color-light-tags-indigo-50: hsl(271, 100%, 94%);
+  --parsec-color-light-tags-indigo-700: hsl(271, 100%, 30%);
   --parsec-color-light-tags-blue-50: var(--parsec-color-light-primary-50);
   --parsec-color-light-tags-blue-700: var(--parsec-color-light-primary-700);
-  --parsec-color-light-tags-orange-50: hsla(28, 100%, 95%, 1);
-  --parsec-color-light-tags-orange-700: hsla(28, 100%, 30%, 1);
+  --parsec-color-light-tags-orange-50: hsl(35, 100%, 94%);
+  --parsec-color-light-tags-orange-700: hsl(35, 100%, 30%);
 
-  /* ------ scrollbar light ------ */
   --parsec-color-light-scrollbar-thumb: hsl(240, 5%, 74%);
   --parsec-color-light-scrollbar-thumb-hover: hsl(240, 5%, 55%);
   --parsec-color-light-scrollbar-track: hsla(0, 0%, 100%, 0);

--- a/lib/theme/variables/_colors-primitives.scss
+++ b/lib/theme/variables/_colors-primitives.scss
@@ -1,0 +1,221 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+/**** Parsec color primitives (theme-agnostic) ****/
+/* Collection "_root colors", mode "Primitives" - single mode, shared by light and dark themes. */
+:root {
+  /* color/base */
+  --parsec-color-base-black: #000000;
+  --parsec-color-base-white: #ffffff;
+
+  /* color/brand */
+  --parsec-color-brand-30: #f0f6ff;
+  --parsec-color-brand-50: #e0efff;
+  --parsec-color-brand-100: #d1e5ff;
+  --parsec-color-brand-200: #add1ff;
+  --parsec-color-brand-300: #66a8ff;
+  --parsec-color-brand-400: #338bff;
+  --parsec-color-brand-500: #006eff;
+  --parsec-color-brand-600: #0058cc;
+  --parsec-color-brand-700: #004299;
+  --parsec-color-brand-800: #002c66;
+  --parsec-color-brand-900: #001633;
+
+  /* color/grey */
+  --parsec-color-grey-10: #fcfcfd;
+  --parsec-color-grey-30: #f6f6f9;
+  --parsec-color-grey-50: #ededf3;
+  --parsec-color-grey-100: #eaeaf1;
+  --parsec-color-grey-200: #e0e0eb;
+  --parsec-color-grey-300: #cecede;
+  --parsec-color-grey-400: #b2b2cc;
+  --parsec-color-grey-500: #8585ad;
+  --parsec-color-grey-600: #5e5e8d;
+  --parsec-color-grey-700: #454569;
+  --parsec-color-grey-800: #373753;
+  --parsec-color-grey-900: #232334;
+  --parsec-color-grey-950: #171724;
+  --parsec-color-grey-970: #0f0f18;
+  --parsec-color-grey-990: #08080d;
+  --parsec-color-grey-890: #202032;
+
+  /* color/blue */
+  --parsec-color-blue-30: #f1f7fe;
+  --parsec-color-blue-50: #e2effd;
+  --parsec-color-blue-100: #d3e7fd;
+  --parsec-color-blue-200: #b2d4fb;
+  --parsec-color-blue-300: #6eaef7;
+  --parsec-color-blue-400: #3e93f4;
+  --parsec-color-blue-500: #0c6cd9;
+  --parsec-color-blue-600: #0b60c1;
+  --parsec-color-blue-700: #084891;
+  --parsec-color-blue-800: #053061;
+  --parsec-color-blue-900: #031830;
+
+  /* color/red */
+  --parsec-color-red-30: #fcf3f4;
+  --parsec-color-red-50: #f9e7e9;
+  --parsec-color-red-100: #f6dade;
+  --parsec-color-red-200: #efbdc4;
+  --parsec-color-red-300: #e18490;
+  --parsec-color-red-400: #d75b6b;
+  --parsec-color-red-500: #b82e40;
+  --parsec-color-red-600: #c20a22;
+  --parsec-color-red-700: #910819;
+  --parsec-color-red-800: #610511;
+  --parsec-color-red-900: #310309;
+
+  /* color/green */
+  --parsec-color-green-30: #f3fcf6;
+  --parsec-color-green-50: #e6f9ee;
+  --parsec-color-green-100: #daf6e5;
+  --parsec-color-green-200: #beefd1;
+  --parsec-color-green-300: #83e2a9;
+  --parsec-color-green-400: #5ad88c;
+  --parsec-color-green-500: #2eb865;
+  --parsec-color-green-600: #29a35a;
+  --parsec-color-green-700: #1d7c43;
+  --parsec-color-green-800: #14522d;
+  --parsec-color-green-900: #0a2916;
+
+  /* color/yellow */
+  --parsec-color-yellow-30: #fefbf0;
+  --parsec-color-yellow-50: #fef7e2;
+  --parsec-color-yellow-100: #fdf3d3;
+  --parsec-color-yellow-200: #efe2be;
+  --parsec-color-yellow-300: #e0c985;
+  --parsec-color-yellow-400: #d6b85c;
+  --parsec-color-yellow-500: #b8952e;
+  --parsec-color-yellow-600: #a38529;
+  --parsec-color-yellow-700: #917008;
+  --parsec-color-yellow-800: #614b05;
+  --parsec-color-yellow-900: #312603;
+
+  /* color/orange */
+  --parsec-color-orange-30: #fff9f0;
+  --parsec-color-orange-50: #fff2e0;
+  --parsec-color-orange-100: #ffecd1;
+  --parsec-color-orange-200: #ffddad;
+  --parsec-color-orange-300: #ffbf66;
+  --parsec-color-orange-400: #ffaa33;
+  --parsec-color-orange-500: #e58600;
+  --parsec-color-orange-600: #cc7700;
+  --parsec-color-orange-700: #995900;
+  --parsec-color-orange-800: #663c00;
+  --parsec-color-orange-900: #331e00;
+
+  /* color/purple */
+  --parsec-color-purple-30: #f7f0ff;
+  --parsec-color-purple-50: #f0e0ff;
+  --parsec-color-purple-100: #e8d1ff;
+  --parsec-color-purple-200: #d6adff;
+  --parsec-color-purple-300: #b266ff;
+  --parsec-color-purple-400: #9933ff;
+  --parsec-color-purple-500: #7300e5;
+  --parsec-color-purple-600: #6600cc;
+  --parsec-color-purple-700: #4d0099;
+  --parsec-color-purple-800: #330066;
+  --parsec-color-purple-900: #1a0033;
+
+  /* color/emerald */
+  --parsec-color-emerald-30: #f0fffc;
+  --parsec-color-emerald-50: #e0fff8;
+  --parsec-color-emerald-100: #d1fff5;
+  --parsec-color-emerald-200: #adffed;
+  --parsec-color-emerald-300: #66ffde;
+  --parsec-color-emerald-400: #33ffd3;
+  --parsec-color-emerald-500: #00e5b4;
+  --parsec-color-emerald-600: #00cca0;
+  --parsec-color-emerald-700: #009978;
+  --parsec-color-emerald-800: #006650;
+  --parsec-color-emerald-900: #003328;
+
+  /* opacity/neutral */
+  --parsec-color-opacity-neutral-50: rgba(21, 21, 30, 0.02);
+  --parsec-color-opacity-neutral-100: rgba(21, 21, 30, 0.04);
+  --parsec-color-opacity-neutral-200: rgba(21, 21, 30, 0.06);
+  --parsec-color-opacity-neutral-300: rgba(21, 21, 30, 0.08);
+  --parsec-color-opacity-neutral-400: rgba(21, 21, 30, 0.1);
+  --parsec-color-opacity-neutral-500: rgba(21, 21, 30, 0.14);
+  --parsec-color-opacity-neutral-600: rgba(21, 21, 30, 0.18);
+  --parsec-color-opacity-neutral-700: rgba(21, 21, 30, 0.24);
+  --parsec-color-opacity-neutral-800: rgba(21, 21, 30, 0.32);
+  --parsec-color-opacity-neutral-900: rgba(21, 21, 30, 0.4);
+
+  /* opacity/inverse */
+  --parsec-color-opacity-inverse-050: rgba(249, 249, 251, 0.02);
+  --parsec-color-opacity-inverse-100: rgba(249, 249, 251, 0.04);
+  --parsec-color-opacity-inverse-200: rgba(249, 249, 251, 0.06);
+  --parsec-color-opacity-inverse-300: rgba(249, 249, 251, 0.08);
+  --parsec-color-opacity-inverse-400: rgba(249, 249, 251, 0.1);
+  --parsec-color-opacity-inverse-500: rgba(249, 249, 251, 0.14);
+  --parsec-color-opacity-inverse-600: rgba(246, 247, 249, 0.18);
+  --parsec-color-opacity-inverse-700: rgba(249, 249, 251, 0.24);
+  --parsec-color-opacity-inverse-800: rgba(249, 249, 251, 0.32);
+  --parsec-color-opacity-inverse-900: rgba(249, 249, 251, 0.4);
+
+  /* shadow/brand */
+  --parsec-color-shadow-brand-100: rgba(0, 110, 255, 0.05);
+  --parsec-color-shadow-brand-200: rgba(0, 110, 255, 0.1);
+  --parsec-color-shadow-brand-300: rgba(0, 110, 255, 0.15);
+  --parsec-color-shadow-brand-400: rgba(0, 110, 255, 0.22);
+  --parsec-color-shadow-brand-500: rgba(0, 110, 255, 0.25);
+  --parsec-color-shadow-brand-600: rgba(0, 110, 255, 0.3);
+  --parsec-color-shadow-brand-700: rgba(0, 110, 255, 0.35);
+  --parsec-color-shadow-brand-800: rgba(0, 110, 255, 0.4);
+  --parsec-color-shadow-brand-900: rgba(0, 110, 255, 0.45);
+
+  /* shadow/grey */
+  --parsec-color-shadow-grey-100: rgba(178, 178, 204, 0.06);
+  --parsec-color-shadow-grey-200: rgba(178, 178, 204, 0.1);
+  --parsec-color-shadow-grey-300: rgba(178, 178, 204, 0.15);
+  --parsec-color-shadow-grey-400: rgba(178, 178, 204, 0.2);
+  --parsec-color-shadow-grey-500: rgba(178, 178, 204, 0.25);
+  --parsec-color-shadow-grey-600: rgba(178, 178, 204, 0.3);
+  --parsec-color-shadow-grey-700: rgba(178, 178, 204, 0.35);
+  --parsec-color-shadow-grey-800: rgba(178, 178, 204, 0.4);
+  --parsec-color-shadow-grey-900: rgba(178, 178, 204, 0.45);
+
+  /* shadow/blue */
+  --parsec-color-shadow-blue-100: rgba(11, 96, 193, 0.05);
+  --parsec-color-shadow-blue-200: rgba(11, 96, 193, 0.1);
+  --parsec-color-shadow-blue-300: rgba(11, 96, 193, 0.15);
+  --parsec-color-shadow-blue-400: rgba(11, 96, 193, 0.2);
+  --parsec-color-shadow-blue-500: rgba(11, 96, 193, 0.25);
+  --parsec-color-shadow-blue-600: rgba(11, 96, 193, 0.3);
+  --parsec-color-shadow-blue-700: rgba(11, 96, 193, 0.35);
+  --parsec-color-shadow-blue-800: rgba(11, 96, 193, 0.4);
+  --parsec-color-shadow-blue-900: rgba(11, 96, 193, 0.45);
+
+  /* shadow/red */
+  --parsec-color-shadow-red-100: rgba(194, 10, 34, 0.05);
+  --parsec-color-shadow-red-200: rgba(194, 10, 34, 0.1);
+  --parsec-color-shadow-red-300: rgba(194, 10, 34, 0.15);
+  --parsec-color-shadow-red-400: rgba(194, 10, 34, 0.2);
+  --parsec-color-shadow-red-500: rgba(194, 10, 34, 0.25);
+  --parsec-color-shadow-red-600: rgba(194, 10, 34, 0.3);
+  --parsec-color-shadow-red-700: rgba(194, 10, 34, 0.35);
+  --parsec-color-shadow-red-800: rgba(194, 10, 34, 0.4);
+  --parsec-color-shadow-red-900: rgba(194, 10, 34, 0.45);
+
+  /* shadow/green */
+  --parsec-color-shadow-green-100: rgba(41, 163, 90, 0.05);
+  --parsec-color-shadow-green-200: rgba(41, 163, 90, 0.1);
+  --parsec-color-shadow-green-300: rgba(41, 163, 90, 0.15);
+  --parsec-color-shadow-green-400: rgba(41, 163, 90, 0.2);
+  --parsec-color-shadow-green-500: rgba(41, 163, 90, 0.25);
+  --parsec-color-shadow-green-600: rgba(41, 163, 90, 0.3);
+  --parsec-color-shadow-green-700: rgba(41, 163, 90, 0.35);
+  --parsec-color-shadow-green-800: rgba(41, 163, 90, 0.4);
+  --parsec-color-shadow-green-900: rgba(41, 163, 90, 0.45);
+
+  /* shadow/yellow */
+  --parsec-color-shadow-yellow-100: rgba(163, 133, 41, 0.05);
+  --parsec-color-shadow-yellow-200: rgba(163, 133, 41, 0.1);
+  --parsec-color-shadow-yellow-300: rgba(163, 133, 41, 0.15);
+  --parsec-color-shadow-yellow-400: rgba(163, 133, 41, 0.2);
+  --parsec-color-shadow-yellow-500: rgba(163, 133, 41, 0.25);
+  --parsec-color-shadow-yellow-600: rgba(163, 133, 41, 0.3);
+  --parsec-color-shadow-yellow-700: rgba(163, 133, 41, 0.35);
+  --parsec-color-shadow-yellow-800: rgba(163, 133, 41, 0.4);
+  --parsec-color-shadow-yellow-900: rgba(163, 133, 41, 0.45);
+}

--- a/lib/theme/variables/_colors-theme.scss
+++ b/lib/theme/variables/_colors-theme.scss
@@ -1,0 +1,563 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+/**** Parsec semantic theme tokens (surface / text / icon / border / shadow) ****/
+
+:root {
+  // ------------ background colors ------------
+  --parsec-color-surface-base-default: var(--parsec-color-base-white);
+  --parsec-color-surface-base-default-secondary: var(--parsec-color-grey-30);
+  --parsec-color-surface-base-page: var(--parsec-color-grey-10);
+  --parsec-color-surface-base-page-secondary: var(--parsec-color-grey-50);
+
+  --parsec-color-surface-elevated-default: var(--parsec-color-grey-900);
+  --parsec-color-surface-elevated-default-hover: var(--parsec-color-grey-800);
+  --parsec-color-surface-elevated-default-pressed: var(--parsec-color-grey-700);
+  --parsec-color-surface-elevated-secondary: var(--parsec-color-grey-950);
+  --parsec-color-surface-elevated-subtle: var(--parsec-color-grey-800);
+  --parsec-color-surface-elevated-subtle-hover: var(--parsec-color-grey-700);
+
+  --parsec-color-surface-brand-default: var(--parsec-color-brand-500);
+  --parsec-color-surface-brand-default-hover: var(--parsec-color-brand-600);
+  --parsec-color-surface-brand-default-pressed: var(--parsec-color-brand-700);
+  --parsec-color-surface-brand-default-subtle: var(--parsec-color-brand-30);
+  --parsec-color-surface-brand-default-subtle-hover: var(--parsec-color-brand-50);
+  --parsec-color-surface-brand-default-subtle-pressed: var(--parsec-color-brand-100);
+
+  --parsec-color-surface-neutral-default: var(--parsec-color-grey-800);
+  --parsec-color-surface-neutral-default-hover: var(--parsec-color-grey-900);
+  --parsec-color-surface-neutral-default-pressed: var(--parsec-color-grey-950);
+  --parsec-color-surface-neutral-default-subtle: var(--parsec-color-grey-10);
+  --parsec-color-surface-neutral-default-subtle-hover: var(--parsec-color-grey-30);
+  --parsec-color-surface-neutral-default-subtle-pressed: var(--parsec-color-grey-50);
+
+  --parsec-color-surface-error-default: var(--parsec-color-red-600);
+  --parsec-color-surface-error-default-hover: var(--parsec-color-red-700);
+  --parsec-color-surface-error-default-pressed: var(--parsec-color-red-800);
+  --parsec-color-surface-error-default-subtle: var(--parsec-color-red-30);
+  --parsec-color-surface-error-default-subtle-hover: var(--parsec-color-red-50);
+  --parsec-color-surface-error-default-subtle-pressed: var(--parsec-color-red-100);
+
+  --parsec-color-surface-success-default: var(--parsec-color-green-600);
+  --parsec-color-surface-success-default-hover: var(--parsec-color-green-700);
+  --parsec-color-surface-success-default-pressed: var(--parsec-color-green-800);
+  --parsec-color-surface-success-default-subtle: var(--parsec-color-green-30);
+  --parsec-color-surface-success-default-subtle-hover: var(--parsec-color-green-50);
+  --parsec-color-surface-success-default-subtle-pressed: var(--parsec-color-green-100);
+
+  --parsec-color-surface-warning-default: var(--parsec-color-yellow-600);
+  --parsec-color-surface-warning-default-hover: var(--parsec-color-yellow-700);
+  --parsec-color-surface-warning-default-pressed: var(--parsec-color-yellow-800);
+  --parsec-color-surface-warning-default-subtle: var(--parsec-color-yellow-30);
+  --parsec-color-surface-warning-default-subtle-hover: var(--parsec-color-yellow-50);
+  --parsec-color-surface-warning-default-subtle-pressed: var(--parsec-color-yellow-100);
+
+  --parsec-color-surface-information-default: var(--parsec-color-blue-600);
+  --parsec-color-surface-information-default-hover: var(--parsec-color-blue-700);
+  --parsec-color-surface-information-default-pressed: var(--parsec-color-blue-800);
+  --parsec-color-surface-information-default-subtle: var(--parsec-color-blue-30);
+  --parsec-color-surface-information-default-subtle-hover: var(--parsec-color-blue-50);
+  --parsec-color-surface-information-default-subtle-pressed: var(--parsec-color-blue-100);
+
+  --parsec-color-surface-extra-orange-default: var(--parsec-color-orange-600);
+  --parsec-color-surface-extra-orange-default-hover: var(--parsec-color-orange-700);
+  --parsec-color-surface-extra-orange-default-pressed: var(--parsec-color-orange-800);
+  --parsec-color-surface-extra-orange-default-subtle: var(--parsec-color-orange-30);
+  --parsec-color-surface-extra-orange-default-subtle-hover: var(--parsec-color-orange-50);
+
+  --parsec-color-surface-extra-orange-default-subtle-pressed: var(--parsec-color-orange-100);
+  --parsec-color-surface-extra-purple-default: var(--parsec-color-purple-600);
+  --parsec-color-surface-extra-purple-default-hover: var(--parsec-color-purple-700);
+  --parsec-color-surface-extra-purple-default-pressed: var(--parsec-color-purple-800);
+  --parsec-color-surface-extra-purple-default-subtle: var(--parsec-color-purple-30);
+  --parsec-color-surface-extra-purple-default-subtle-hover: var(--parsec-color-purple-50);
+  --parsec-color-surface-extra-purple-default-subtle-pressed: var(--parsec-color-purple-100);
+
+  --parsec-color-surface-extra-emerald-default: var(--parsec-color-emerald-600);
+  --parsec-color-surface-extra-emerald-default-hover: var(--parsec-color-emerald-700);
+  --parsec-color-surface-extra-emerald-default-pressed: var(--parsec-color-emerald-800);
+  --parsec-color-surface-extra-emerald-default-subtle: var(--parsec-color-emerald-30);
+  --parsec-color-surface-extra-emerald-default-subtle-hover: var(--parsec-color-emerald-50);
+  --parsec-color-surface-extra-emerald-default-subtle-pressed: var(--parsec-color-emerald-100);
+
+  --parsec-color-surface-disabled-default: var(--parsec-color-grey-200);
+  --parsec-color-surface-disabled-on-color: var(--parsec-color-grey-300);
+
+  // ----------- text colors ------------
+  --parsec-color-text-base-hero: var(--parsec-color-grey-900);
+  --parsec-color-text-base-heading: var(--parsec-color-grey-900);
+  --parsec-color-text-base-body: var(--parsec-color-grey-800);
+  --parsec-color-text-base-description: var(--parsec-color-grey-600);
+  --parsec-color-text-base-label: var(--parsec-color-grey-700);
+  --parsec-color-text-base-placeholder: var(--parsec-color-grey-400);
+
+  --parsec-color-text-elevated-heading: var(--parsec-color-grey-100);
+  --parsec-color-text-elevated-body: var(--parsec-color-grey-200);
+  --parsec-color-text-elevated-label: var(--parsec-color-grey-300);
+  --parsec-color-text-elevated-placeholder: var(--parsec-color-grey-500);
+  --parsec-color-text-elevated-description: var(--parsec-color-grey-400);
+  --parsec-color-text-elevated-link: var(--parsec-color-brand-300);
+
+  --parsec-color-text-on-color-hero: var(--parsec-color-grey-10);
+  --parsec-color-text-on-color-heading: var(--parsec-color-grey-10);
+  --parsec-color-text-on-color-body: var(--parsec-color-grey-50);
+  --parsec-color-text-on-color-caption: var(--parsec-color-grey-50);
+  --parsec-color-text-on-color-label: var(--parsec-color-grey-30);
+  --parsec-color-text-on-color-placeholder: var(--parsec-color-grey-300);
+
+  --parsec-color-text-brand-default: var(--parsec-color-brand-500);
+  --parsec-color-text-brand-default-hover: var(--parsec-color-brand-600);
+  --parsec-color-text-brand-on-color: var(--parsec-color-brand-30);
+  --parsec-color-text-brand-on-color-hover: var(--parsec-color-brand-50);
+
+  --parsec-color-text-neutral-default: var(--parsec-color-grey-700);
+  --parsec-color-text-neutral-default-hover: var(--parsec-color-grey-800);
+  --parsec-color-text-neutral-on-color: var(--parsec-color-grey-50);
+  --parsec-color-text-neutral-on-color-hover: var(--parsec-color-grey-100);
+
+  --parsec-color-text-error-default: var(--parsec-color-red-600);
+  --parsec-color-text-error-default-hover: var(--parsec-color-red-700);
+  --parsec-color-text-error-on-color: var(--parsec-color-grey-10);
+  --parsec-color-text-error-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-text-success-default: var(--parsec-color-green-600);
+  --parsec-color-text-success-default-hover: var(--parsec-color-green-700);
+  --parsec-color-text-success-on-color: var(--parsec-color-grey-10);
+  --parsec-color-text-success-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-text-warning-default: var(--parsec-color-yellow-600);
+  --parsec-color-text-warning-default-hover: var(--parsec-color-yellow-700);
+  --parsec-color-text-warning-on-color: var(--parsec-color-grey-10);
+  --parsec-color-text-warning-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-text-information-default: var(--parsec-color-blue-600);
+  --parsec-color-text-information-default-hover: var(--parsec-color-blue-700);
+  --parsec-color-text-information-on-color: var(--parsec-color-grey-10);
+  --parsec-color-text-information-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-text-extra-orange-default: var(--parsec-color-orange-600);
+  --parsec-color-text-extra-orange-default-hover: var(--parsec-color-orange-700);
+  --parsec-color-text-extra-orange-default-subtle: var(--parsec-color-orange-30);
+  --parsec-color-text-extra-orange-default-subtle-hover: var(--parsec-color-orange-50);
+
+  --parsec-color-text-extra-purple-default: var(--parsec-color-purple-600);
+  --parsec-color-text-extra-purple-default-hover: var(--parsec-color-purple-700);
+  --parsec-color-text-extra-purple-default-subtle: var(--parsec-color-purple-30);
+  --parsec-color-text-extra-purple-default-subtle-hover: var(--parsec-color-purple-50);
+
+  --parsec-color-text-extra-emerald-default: var(--parsec-color-emerald-600);
+  --parsec-color-text-extra-emerald-default-hover: var(--parsec-color-emerald-700);
+  --parsec-color-text-extra-emerald-default-subtle: var(--parsec-color-emerald-30);
+  --parsec-color-text-extra-emerald-default-subtle-hover: var(--parsec-color-emerald-50);
+
+  --parsec-color-text-disabled-default: var(--parsec-color-grey-400);
+  --parsec-color-text-disabled-on-color: var(--parsec-color-grey-500);
+
+  // ----------- icon colors ------------
+  --parsec-color-icon-brand-default: var(--parsec-color-brand-500);
+  --parsec-color-icon-brand-default-hover: var(--parsec-color-brand-600);
+  --parsec-color-icon-brand-on-color: var(--parsec-color-brand-30);
+  --parsec-color-icon-brand-on-color-hover: var(--parsec-color-brand-50);
+
+  --parsec-color-icon-neutral-default: var(--parsec-color-grey-700);
+  --parsec-color-icon-neutral-default-hover: var(--parsec-color-grey-800);
+  --parsec-color-icon-neutral-on-color: var(--parsec-color-grey-50);
+  --parsec-color-icon-neutral-on-color-hover: var(--parsec-color-grey-100);
+
+  --parsec-color-icon-error-default: var(--parsec-color-red-600);
+  --parsec-color-icon-error-default-hover: var(--parsec-color-red-700);
+  --parsec-color-icon-error-on-color: var(--parsec-color-grey-10);
+  --parsec-color-icon-error-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-icon-success-default: var(--parsec-color-green-600);
+  --parsec-color-icon-success-default-hover: var(--parsec-color-green-700);
+  --parsec-color-icon-success-on-color: var(--parsec-color-grey-10);
+  --parsec-color-icon-success-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-icon-warning-default: var(--parsec-color-yellow-600);
+  --parsec-color-icon-warning-default-hover: var(--parsec-color-yellow-700);
+  --parsec-color-icon-warning-on-color: var(--parsec-color-grey-10);
+  --parsec-color-icon-warning-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-icon-information-default: var(--parsec-color-blue-600);
+  --parsec-color-icon-information-default-hover: var(--parsec-color-blue-700);
+  --parsec-color-icon-information-on-color: var(--parsec-color-grey-10);
+  --parsec-color-icon-information-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-icon-extra-orange-default: var(--parsec-color-orange-600);
+  --parsec-color-icon-extra-orange-default-hover: var(--parsec-color-orange-700);
+  --parsec-color-icon-extra-orange-default-subtle: var(--parsec-color-orange-30);
+  --parsec-color-icon-extra-orange-default-subtle-hover: var(--parsec-color-orange-50);
+
+  --parsec-color-icon-extra-purple-default: var(--parsec-color-purple-600);
+  --parsec-color-icon-extra-purple-default-hover: var(--parsec-color-purple-700);
+  --parsec-color-icon-extra-purple-default-subtle: var(--parsec-color-purple-30);
+  --parsec-color-icon-extra-purple-default-subtle-hover: var(--parsec-color-purple-50);
+
+  --parsec-color-icon-extra-emerald-default: var(--parsec-color-emerald-600);
+  --parsec-color-icon-extra-emerald-default-hover: var(--parsec-color-emerald-700);
+  --parsec-color-icon-extra-emerald-default-subtle: var(--parsec-color-emerald-30);
+  --parsec-color-icon-extra-emerald-default-subtle-hover: var(--parsec-color-emerald-50);
+
+  --parsec-color-icon-disabled-default: var(--parsec-color-grey-400);
+  --parsec-color-icon-disabled-on-color: var(--parsec-color-grey-500);
+
+  // ----------- border colors ------------
+  --parsec-color-border-base-default: var(--parsec-color-grey-200);
+  --parsec-color-border-base-on-color: var(--parsec-color-base-white);
+
+  --parsec-color-border-elevated-default: var(--parsec-color-grey-700);
+  --parsec-color-border-elevated-subtle: var(--parsec-color-grey-800);
+
+  --parsec-color-border-brand-default: var(--parsec-color-brand-500);
+  --parsec-color-border-brand-default-hover: var(--parsec-color-brand-600);
+  --parsec-color-border-brand-default-subtle: var(--parsec-color-brand-30);
+  --parsec-color-border-brand-default-subtle-hover: var(--parsec-color-brand-50);
+
+  --parsec-color-border-neutral-default: var(--parsec-color-grey-700);
+  --parsec-color-border-neutral-default-hover: var(--parsec-color-grey-800);
+  --parsec-color-border-neutral-default-subtle: var(--parsec-color-grey-50);
+  --parsec-color-border-neutral-default-subtle-hover: var(--parsec-color-grey-100);
+
+  --parsec-color-border-error-default: var(--parsec-color-red-600);
+  --parsec-color-border-error-default-hover: var(--parsec-color-red-700);
+  --parsec-color-border-error-default-subtle: var(--parsec-color-red-50);
+  --parsec-color-border-error-default-subtle-hover: var(--parsec-color-red-100);
+
+  --parsec-color-border-success-default: var(--parsec-color-green-600);
+  --parsec-color-border-success-default-hover: var(--parsec-color-green-700);
+  --parsec-color-border-success-default-subtle: var(--parsec-color-green-50);
+  --parsec-color-border-success-default-subtle-hover: var(--parsec-color-green-100);
+
+  --parsec-color-border-warning-default: var(--parsec-color-yellow-600);
+  --parsec-color-border-warning-default-hover: var(--parsec-color-yellow-700);
+  --parsec-color-border-warning-default-subtle: var(--parsec-color-yellow-50);
+  --parsec-color-border-warning-default-subtle-hover: var(--parsec-color-yellow-100);
+
+  --parsec-color-border-information-default: var(--parsec-color-blue-600);
+  --parsec-color-border-information-default-hover: var(--parsec-color-blue-700);
+  --parsec-color-border-information-default-subtle: var(--parsec-color-blue-50);
+  --parsec-color-border-information-default-subtle-hover: var(--parsec-color-blue-100);
+
+  --parsec-color-border-extra-orange-default: var(--parsec-color-orange-600);
+  --parsec-color-border-extra-orange-default-hover: var(--parsec-color-orange-700);
+  --parsec-color-border-extra-orange-default-subtle: var(--parsec-color-orange-30);
+  --parsec-color-border-extra-orange-default-subtle-hover: var(--parsec-color-orange-50);
+
+  --parsec-color-border-extra-purple-default: var(--parsec-color-purple-600);
+  --parsec-color-border-extra-purple-default-hover: var(--parsec-color-purple-700);
+  --parsec-color-border-extra-purple-default-subtle: var(--parsec-color-purple-30);
+  --parsec-color-border-extra-purple-default-subtle-hover: var(--parsec-color-purple-50);
+
+  --parsec-color-border-extra-emerald-default: var(--parsec-color-emerald-600);
+  --parsec-color-border-extra-emerald-default-hover: var(--parsec-color-emerald-700);
+  --parsec-color-border-extra-emerald-default-subtle: var(--parsec-color-emerald-30);
+  --parsec-color-border-extra-emerald-default-subtle-hover: var(--parsec-color-emerald-50);
+
+  --parsec-color-border-disabled-default: var(--parsec-color-grey-200);
+  --parsec-color-border-disabled-on-color: var(--parsec-color-grey-300);
+
+  // ----------- shadow colors ------------
+  --parsec-color-shadow-brand-lighter: var(--parsec-color-shadow-brand-300);
+  --parsec-color-shadow-brand-moderate: var(--parsec-color-shadow-brand-500);
+  --parsec-color-shadow-brand-strong: var(--parsec-color-shadow-brand-700);
+
+  --parsec-color-shadow-neutral-lighter: var(--parsec-color-shadow-grey-300);
+  --parsec-color-shadow-neutral-moderate: var(--parsec-color-shadow-grey-500);
+  --parsec-color-shadow-neutral-strong: var(--parsec-color-shadow-grey-700);
+
+  --parsec-color-shadow-error-lighter: var(--parsec-color-shadow-red-300);
+  --parsec-color-shadow-error-moderate: var(--parsec-color-shadow-red-500);
+  --parsec-color-shadow-error-strong: var(--parsec-color-shadow-red-700);
+
+  --parsec-color-shadow-success-lighter: var(--parsec-color-shadow-green-300);
+  --parsec-color-shadow-success-moderate: var(--parsec-color-shadow-green-500);
+  --parsec-color-shadow-success-strong: var(--parsec-color-shadow-green-700);
+
+  --parsec-color-shadow-warning-lighter: var(--parsec-color-shadow-yellow-300);
+  --parsec-color-shadow-warning-moderate: var(--parsec-color-shadow-yellow-500);
+  --parsec-color-shadow-warning-strong: var(--parsec-color-shadow-yellow-700);
+
+  --parsec-color-shadow-information-lighter: var(--parsec-color-shadow-blue-300);
+  --parsec-color-shadow-information-moderate: var(--parsec-color-shadow-blue-500);
+  --parsec-color-shadow-information-strong: var(--parsec-color-shadow-blue-700);
+}
+
+body.ms-theme-dark {
+  // ------------ background colors ------------
+  --parsec-color-surface-base-default: var(--parsec-color-grey-990);
+  --parsec-color-surface-base-default-secondary: var(--parsec-color-grey-900);
+  --parsec-color-surface-base-page: var(--parsec-color-grey-950);
+  --parsec-color-surface-base-page-secondary: var(--parsec-color-grey-800);
+
+  --parsec-color-surface-elevated-default: var(--parsec-color-grey-990);
+  --parsec-color-surface-elevated-default-hover: var(--parsec-color-grey-970);
+  --parsec-color-surface-elevated-default-pressed: var(--parsec-color-grey-950);
+  --parsec-color-surface-elevated-secondary: var(--parsec-color-base-black);
+  --parsec-color-surface-elevated-subtle: var(--parsec-color-grey-970);
+  --parsec-color-surface-elevated-subtle-hover: var(--parsec-color-grey-950);
+
+  --parsec-color-surface-brand-default: var(--parsec-color-brand-500);
+  --parsec-color-surface-brand-default-hover: var(--parsec-color-brand-400);
+  --parsec-color-surface-brand-default-pressed: var(--parsec-color-brand-600);
+  --parsec-color-surface-brand-default-subtle: var(--parsec-color-brand-900);
+  --parsec-color-surface-brand-default-subtle-hover: var(--parsec-color-brand-800);
+  --parsec-color-surface-brand-default-subtle-pressed: var(--parsec-color-brand-100);
+
+  --parsec-color-surface-neutral-default: var(--parsec-color-grey-300);
+  --parsec-color-surface-neutral-default-hover: var(--parsec-color-grey-200);
+  --parsec-color-surface-neutral-default-pressed: var(--parsec-color-grey-400);
+  --parsec-color-surface-neutral-default-subtle: var(--parsec-color-grey-800);
+  --parsec-color-surface-neutral-default-subtle-hover: var(--parsec-color-grey-700);
+  --parsec-color-surface-neutral-default-subtle-pressed: var(--parsec-color-grey-600);
+
+  --parsec-color-surface-error-default: var(--parsec-color-red-500);
+  --parsec-color-surface-error-default-hover: var(--parsec-color-red-400);
+  --parsec-color-surface-error-default-pressed: var(--parsec-color-red-600);
+  --parsec-color-surface-error-default-subtle: var(--parsec-color-red-900);
+  --parsec-color-surface-error-default-subtle-hover: var(--parsec-color-red-800);
+  --parsec-color-surface-error-default-subtle-pressed: var(--parsec-color-red-100);
+
+  --parsec-color-surface-success-default: var(--parsec-color-green-500);
+  --parsec-color-surface-success-default-hover: var(--parsec-color-green-400);
+  --parsec-color-surface-success-default-pressed: var(--parsec-color-green-600);
+  --parsec-color-surface-success-default-subtle: var(--parsec-color-green-900);
+  --parsec-color-surface-success-default-subtle-hover: var(--parsec-color-green-800);
+  --parsec-color-surface-success-default-subtle-pressed: var(--parsec-color-green-100);
+
+  --parsec-color-surface-warning-default: var(--parsec-color-yellow-500);
+  --parsec-color-surface-warning-default-hover: var(--parsec-color-yellow-400);
+  --parsec-color-surface-warning-default-pressed: var(--parsec-color-yellow-600);
+  --parsec-color-surface-warning-default-subtle: var(--parsec-color-yellow-900);
+  --parsec-color-surface-warning-default-subtle-hover: var(--parsec-color-yellow-800);
+  --parsec-color-surface-warning-default-subtle-pressed: var(--parsec-color-yellow-100);
+
+  --parsec-color-surface-information-default: var(--parsec-color-blue-500);
+  --parsec-color-surface-information-default-hover: var(--parsec-color-blue-400);
+  --parsec-color-surface-information-default-pressed: var(--parsec-color-blue-600);
+  --parsec-color-surface-information-default-subtle: var(--parsec-color-blue-900);
+  --parsec-color-surface-information-default-subtle-hover: var(--parsec-color-blue-800);
+  --parsec-color-surface-information-default-subtle-pressed: var(--parsec-color-blue-100);
+
+  --parsec-color-surface-extra-orange-default: var(--parsec-color-orange-400);
+  --parsec-color-surface-extra-orange-default-hover: var(--parsec-color-orange-300);
+  --parsec-color-surface-extra-orange-default-pressed: var(--parsec-color-orange-500);
+  --parsec-color-surface-extra-orange-default-subtle: var(--parsec-color-orange-900);
+  --parsec-color-surface-extra-orange-default-subtle-hover: var(--parsec-color-orange-800);
+  --parsec-color-surface-extra-orange-default-subtle-pressed: var(--parsec-color-orange-100);
+
+  --parsec-color-surface-extra-purple-default: var(--parsec-color-purple-400);
+  --parsec-color-surface-extra-purple-default-hover: var(--parsec-color-purple-300);
+  --parsec-color-surface-extra-purple-default-pressed: var(--parsec-color-purple-500);
+  --parsec-color-surface-extra-purple-default-subtle: var(--parsec-color-purple-900);
+  --parsec-color-surface-extra-purple-default-subtle-hover: var(--parsec-color-purple-800);
+  --parsec-color-surface-extra-purple-default-subtle-pressed: var(--parsec-color-purple-100);
+
+  --parsec-color-surface-extra-emerald-default: var(--parsec-color-emerald-400);
+  --parsec-color-surface-extra-emerald-default-hover: var(--parsec-color-emerald-300);
+  --parsec-color-surface-extra-emerald-default-pressed: var(--parsec-color-emerald-500);
+  --parsec-color-surface-extra-emerald-default-subtle: var(--parsec-color-emerald-900);
+  --parsec-color-surface-extra-emerald-default-subtle-hover: var(--parsec-color-emerald-800);
+  --parsec-color-surface-extra-emerald-default-subtle-pressed: var(--parsec-color-emerald-700);
+
+  --parsec-color-surface-disabled-default: var(--parsec-color-grey-800);
+  --parsec-color-surface-disabled-on-color: var(--parsec-color-grey-700);
+
+  // ----------- text colors ------------
+  --parsec-color-text-base-hero: var(--parsec-color-grey-10);
+  --parsec-color-text-base-heading: var(--parsec-color-grey-10);
+  --parsec-color-text-base-body: var(--parsec-color-grey-200);
+  --parsec-color-text-base-description: var(--parsec-color-grey-400);
+  --parsec-color-text-base-label: var(--parsec-color-grey-300);
+  --parsec-color-text-base-placeholder: var(--parsec-color-grey-400);
+
+  --parsec-color-text-elevated-heading: var(--parsec-color-grey-50);
+  --parsec-color-text-elevated-body: var(--parsec-color-grey-300);
+  --parsec-color-text-elevated-label: var(--parsec-color-grey-400);
+  --parsec-color-text-elevated-placeholder: var(--parsec-color-grey-600);
+  --parsec-color-text-elevated-description: var(--parsec-color-grey-500);
+  --parsec-color-text-elevated-link: var(--parsec-color-brand-300);
+
+  --parsec-color-text-on-color-hero: var(--parsec-color-grey-890);
+  --parsec-color-text-on-color-heading: var(--parsec-color-grey-890);
+  --parsec-color-text-on-color-body: var(--parsec-color-grey-50);
+  --parsec-color-text-on-color-caption: var(--parsec-color-grey-200);
+  --parsec-color-text-on-color-label: var(--parsec-color-grey-100);
+  --parsec-color-text-on-color-placeholder: var(--parsec-color-grey-300);
+
+  --parsec-color-text-brand-default: var(--parsec-color-brand-300);
+  --parsec-color-text-brand-default-hover: var(--parsec-color-brand-200);
+  --parsec-color-text-brand-on-color: var(--parsec-color-brand-30);
+  --parsec-color-text-brand-on-color-hover: var(--parsec-color-brand-50);
+
+  --parsec-color-text-neutral-default: var(--parsec-color-grey-300);
+  --parsec-color-text-neutral-default-hover: var(--parsec-color-grey-200);
+  --parsec-color-text-neutral-on-color: var(--parsec-color-grey-900);
+  --parsec-color-text-neutral-on-color-hover: var(--parsec-color-grey-100);
+
+  --parsec-color-text-error-default: var(--parsec-color-red-300);
+  --parsec-color-text-error-default-hover: var(--parsec-color-red-200);
+  --parsec-color-text-error-on-color: var(--parsec-color-grey-890);
+  --parsec-color-text-error-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-text-success-default: var(--parsec-color-green-300);
+  --parsec-color-text-success-default-hover: var(--parsec-color-green-200);
+  --parsec-color-text-success-on-color: var(--parsec-color-grey-890);
+  --parsec-color-text-success-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-text-warning-default: var(--parsec-color-yellow-300);
+  --parsec-color-text-warning-default-hover: var(--parsec-color-yellow-200);
+  --parsec-color-text-warning-on-color: var(--parsec-color-grey-890);
+  --parsec-color-text-warning-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-text-information-default: var(--parsec-color-blue-300);
+  --parsec-color-text-information-default-hover: var(--parsec-color-blue-200);
+  --parsec-color-text-information-on-color: var(--parsec-color-grey-890);
+  --parsec-color-text-information-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-text-extra-orange-default: var(--parsec-color-orange-300);
+  --parsec-color-text-extra-orange-default-hover: var(--parsec-color-orange-200);
+  --parsec-color-text-extra-orange-default-subtle: var(--parsec-color-orange-100);
+  --parsec-color-text-extra-orange-default-subtle-hover: var(--parsec-color-orange-50);
+
+  --parsec-color-text-extra-purple-default: var(--parsec-color-purple-300);
+  --parsec-color-text-extra-purple-default-hover: var(--parsec-color-purple-200);
+  --parsec-color-text-extra-purple-default-subtle: var(--parsec-color-purple-100);
+  --parsec-color-text-extra-purple-default-subtle-hover: var(--parsec-color-purple-50);
+
+  --parsec-color-text-extra-emerald-default: var(--parsec-color-emerald-300);
+  --parsec-color-text-extra-emerald-default-hover: var(--parsec-color-emerald-200);
+  --parsec-color-text-extra-emerald-default-subtle: var(--parsec-color-emerald-100);
+  --parsec-color-text-extra-emerald-default-subtle-hover: var(--parsec-color-emerald-50);
+
+  --parsec-color-text-disabled-default: var(--parsec-color-grey-600);
+  --parsec-color-text-disabled-on-color: var(--parsec-color-grey-500);
+
+  // ----------- icon colors ------------
+  --parsec-color-icon-brand-default: var(--parsec-color-brand-300);
+  --parsec-color-icon-brand-default-hover: var(--parsec-color-brand-200);
+  --parsec-color-icon-brand-on-color: var(--parsec-color-brand-30);
+  --parsec-color-icon-brand-on-color-hover: var(--parsec-color-brand-50);
+
+  --parsec-color-icon-neutral-default: var(--parsec-color-grey-200);
+  --parsec-color-icon-neutral-default-hover: var(--parsec-color-grey-100);
+  --parsec-color-icon-neutral-on-color: var(--parsec-color-grey-900);
+  --parsec-color-icon-neutral-on-color-hover: var(--parsec-color-grey-100);
+
+  --parsec-color-icon-error-default: var(--parsec-color-red-300);
+  --parsec-color-icon-error-default-hover: var(--parsec-color-red-200);
+  --parsec-color-icon-error-on-color: var(--parsec-color-grey-890);
+  --parsec-color-icon-error-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-icon-success-default: var(--parsec-color-green-300);
+  --parsec-color-icon-success-default-hover: var(--parsec-color-green-200);
+  --parsec-color-icon-success-on-color: var(--parsec-color-grey-890);
+  --parsec-color-icon-success-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-icon-warning-default: var(--parsec-color-yellow-300);
+  --parsec-color-icon-warning-default-hover: var(--parsec-color-yellow-200);
+  --parsec-color-icon-warning-on-color: var(--parsec-color-grey-890);
+  --parsec-color-icon-warning-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-icon-information-default: var(--parsec-color-blue-300);
+  --parsec-color-icon-information-default-hover: var(--parsec-color-blue-200);
+  --parsec-color-icon-information-on-color: var(--parsec-color-grey-890);
+  --parsec-color-icon-information-on-color-hover: var(--parsec-color-grey-50);
+
+  --parsec-color-icon-extra-orange-default: var(--parsec-color-orange-300);
+  --parsec-color-icon-extra-orange-default-hover: var(--parsec-color-orange-200);
+  --parsec-color-icon-extra-orange-default-subtle: var(--parsec-color-orange-100);
+  --parsec-color-icon-extra-orange-default-subtle-hover: var(--parsec-color-orange-50);
+
+  --parsec-color-icon-extra-purple-default: var(--parsec-color-purple-300);
+  --parsec-color-icon-extra-purple-default-hover: var(--parsec-color-purple-200);
+  --parsec-color-icon-extra-purple-default-subtle: var(--parsec-color-purple-100);
+  --parsec-color-icon-extra-purple-default-subtle-hover: var(--parsec-color-purple-50);
+
+  --parsec-color-icon-extra-emerald-default: var(--parsec-color-emerald-300);
+  --parsec-color-icon-extra-emerald-default-hover: var(--parsec-color-emerald-200);
+  --parsec-color-icon-extra-emerald-default-subtle: var(--parsec-color-emerald-100);
+  --parsec-color-icon-extra-emerald-default-subtle-hover: var(--parsec-color-emerald-50);
+
+  --parsec-color-icon-disabled-default: var(--parsec-color-grey-600);
+  --parsec-color-icon-disabled-on-color: var(--parsec-color-grey-500);
+
+  // ----------- border colors ------------
+  --parsec-color-border-base-default: var(--parsec-color-grey-600);
+  --parsec-color-border-base-on-color: var(--parsec-color-grey-890);
+
+  --parsec-color-border-elevated-default: var(--parsec-color-grey-800);
+  --parsec-color-border-elevated-subtle: var(--parsec-color-grey-900);
+
+  --parsec-color-border-brand-default: var(--parsec-color-brand-400);
+  --parsec-color-border-brand-default-hover: var(--parsec-color-brand-300);
+  --parsec-color-border-brand-default-subtle: var(--parsec-color-brand-800);
+  --parsec-color-border-brand-default-subtle-hover: var(--parsec-color-brand-50);
+
+  --parsec-color-border-neutral-default: var(--parsec-color-grey-200);
+  --parsec-color-border-neutral-default-hover: var(--parsec-color-grey-100);
+  --parsec-color-border-neutral-default-subtle: var(--parsec-color-grey-600);
+  --parsec-color-border-neutral-default-subtle-hover: var(--parsec-color-grey-100);
+
+  --parsec-color-border-error-default: var(--parsec-color-red-400);
+  --parsec-color-border-error-default-hover: var(--parsec-color-red-300);
+  --parsec-color-border-error-default-subtle: var(--parsec-color-red-800);
+  --parsec-color-border-error-default-subtle-hover: var(--parsec-color-red-700);
+
+  --parsec-color-border-success-default: var(--parsec-color-green-400);
+  --parsec-color-border-success-default-hover: var(--parsec-color-green-300);
+  --parsec-color-border-success-default-subtle: var(--parsec-color-green-800);
+  --parsec-color-border-success-default-subtle-hover: var(--parsec-color-green-100);
+
+  --parsec-color-border-warning-default: var(--parsec-color-yellow-400);
+  --parsec-color-border-warning-default-hover: var(--parsec-color-yellow-300);
+  --parsec-color-border-warning-default-subtle: var(--parsec-color-yellow-800);
+  --parsec-color-border-warning-default-subtle-hover: var(--parsec-color-yellow-100);
+
+  --parsec-color-border-information-default: var(--parsec-color-blue-400);
+  --parsec-color-border-information-default-hover: var(--parsec-color-blue-300);
+  --parsec-color-border-information-default-subtle: var(--parsec-color-blue-800);
+  --parsec-color-border-information-default-subtle-hover: var(--parsec-color-blue-100);
+
+  --parsec-color-border-extra-orange-default: var(--parsec-color-orange-400);
+  --parsec-color-border-extra-orange-default-hover: var(--parsec-color-orange-300);
+  --parsec-color-border-extra-orange-default-subtle: var(--parsec-color-orange-800);
+  --parsec-color-border-extra-orange-default-subtle-hover: var(--parsec-color-orange-50);
+
+  --parsec-color-border-extra-purple-default: var(--parsec-color-purple-400);
+  --parsec-color-border-extra-purple-default-hover: var(--parsec-color-purple-300);
+  --parsec-color-border-extra-purple-default-subtle: var(--parsec-color-purple-800);
+  --parsec-color-border-extra-purple-default-subtle-hover: var(--parsec-color-purple-50);
+
+  --parsec-color-border-extra-emerald-default: var(--parsec-color-emerald-400);
+  --parsec-color-border-extra-emerald-default-hover: var(--parsec-color-emerald-300);
+  --parsec-color-border-extra-emerald-default-subtle: var(--parsec-color-emerald-800);
+  --parsec-color-border-extra-emerald-default-subtle-hover: var(--parsec-color-emerald-50);
+
+  --parsec-color-border-disabled-default: var(--parsec-color-grey-700);
+  --parsec-color-border-disabled-on-color: var(--parsec-color-grey-600);
+
+  // ----------- shadow colors ------------
+  --parsec-color-shadow-brand-lighter: var(--parsec-color-shadow-brand-300);
+  --parsec-color-shadow-brand-moderate: var(--parsec-color-shadow-brand-500);
+  --parsec-color-shadow-brand-strong: var(--parsec-color-shadow-brand-700);
+
+  --parsec-color-shadow-neutral-lighter: var(--parsec-color-shadow-grey-300);
+  --parsec-color-shadow-neutral-moderate: var(--parsec-color-shadow-grey-500);
+  --parsec-color-shadow-neutral-strong: var(--parsec-color-shadow-grey-700);
+
+  --parsec-color-shadow-error-lighter: var(--parsec-color-shadow-red-300);
+  --parsec-color-shadow-error-moderate: var(--parsec-color-shadow-red-500);
+  --parsec-color-shadow-error-strong: var(--parsec-color-shadow-red-700);
+
+  --parsec-color-shadow-success-lighter: var(--parsec-color-shadow-green-300);
+  --parsec-color-shadow-success-moderate: var(--parsec-color-shadow-green-500);
+  --parsec-color-shadow-success-strong: var(--parsec-color-shadow-green-700);
+
+  --parsec-color-shadow-warning-lighter: var(--parsec-color-shadow-yellow-300);
+  --parsec-color-shadow-warning-moderate: var(--parsec-color-shadow-yellow-500);
+  --parsec-color-shadow-warning-strong: var(--parsec-color-shadow-yellow-700);
+
+  --parsec-color-shadow-information-lighter: var(--parsec-color-shadow-blue-300);
+  --parsec-color-shadow-information-moderate: var(--parsec-color-shadow-blue-500);
+  --parsec-color-shadow-information-strong: var(--parsec-color-shadow-blue-700);
+}

--- a/lib/theme/variables/_colors.scss
+++ b/lib/theme/variables/_colors.scss
@@ -1,81 +1,82 @@
 /* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
 
-/**** Parsec colors ****/
+@use 'colors-light';
+
+/**** Aliases dynamiques (pointent vers light par défaut, surchargés en dark via body.ms-theme-dark) ****/
 :root {
-  /*** Light ***/
   /* gradient */
-  --parsec-color-light-gradient: linear-gradient(113.02deg, #4092ff -1.49%, #0058cc 100%);
-  --parsec-color-light-gradient-background: linear-gradient(
-    113deg,
-    var(--parsec-color-light-primary-500) -1.49%,
-    var(--parsec-color-light-primary-600) 100%
-  );
+  --parsec-color-gradient: var(--parsec-color-light-gradient);
+  --parsec-color-gradient-background: var(--parsec-color-light-gradient-background);
 
-  /* Outline */
-  --parsec-color-light-outline: rgba(102, 168, 255, 0.25);
+  /* outline */
+  --parsec-color-outline: var(--parsec-color-light-outline);
 
-  /* Primary */
-  --parsec-color-light-primary-30-opacity15: hsla(212, 100%, 97.1%, 0.15);
-  --parsec-color-light-primary-30: hsla(212, 100%, 97%, 1);
-  --parsec-color-light-primary-50: hsla(212, 100%, 95%, 1);
-  --parsec-color-light-primary-100: hsla(214, 100%, 90%, 1);
-  --parsec-color-light-primary-200: hsla(214, 100%, 80%, 1);
-  --parsec-color-light-primary-300: hsla(214, 100%, 70%, 1);
-  --parsec-color-light-primary-400: hsla(214, 100%, 60%, 1);
-  --parsec-color-light-primary-500: hsla(214, 100%, 50%, 1);
-  --parsec-color-light-primary-600: hsla(214, 100%, 40%, 1);
-  --parsec-color-light-primary-700: hsla(214, 100%, 30%, 1);
-  --parsec-color-light-primary-800: hsla(214, 100%, 20%, 1);
-  --parsec-color-light-primary-900: hsla(214, 100%, 10%, 1);
+  /* primary */
+  --parsec-color-primary-30-opacity15: var(--parsec-color-light-primary-30-opacity15);
+  --parsec-color-primary-30: var(--parsec-color-light-primary-30);
+  --parsec-color-primary-50: var(--parsec-color-light-primary-50);
+  --parsec-color-primary-100: var(--parsec-color-light-primary-100);
+  --parsec-color-primary-200: var(--parsec-color-light-primary-200);
+  --parsec-color-primary-300: var(--parsec-color-light-primary-300);
+  --parsec-color-primary-400: var(--parsec-color-light-primary-400);
+  --parsec-color-primary-500: var(--parsec-color-light-primary-500);
+  --parsec-color-primary-600: var(--parsec-color-light-primary-600);
+  --parsec-color-primary-700: var(--parsec-color-light-primary-700);
+  --parsec-color-primary-800: var(--parsec-color-light-primary-800);
+  --parsec-color-primary-900: var(--parsec-color-light-primary-900);
 
-  /* Secondary */
-  --parsec-color-light-secondary-opacity30: hsla(0, 0%, 100%, 0.3);
-  --parsec-color-light-secondary-black: hsla(240, 20%, 13%, 1);
-  --parsec-color-light-secondary-contrast: hsla(240, 20%, 20%, 1);
-  --parsec-color-light-secondary-text: hsla(240, 20%, 30%, 1);
-  --parsec-color-light-secondary-soft-text: hsla(240, 20%, 40%, 1);
-  --parsec-color-light-secondary-hard-grey: hsla(240, 20%, 50%, 1);
-  --parsec-color-light-secondary-grey: hsla(240, 20%, 60%, 1);
-  --parsec-color-light-secondary-soft-grey: hsla(240, 20%, 70%, 1);
-  --parsec-color-light-secondary-light: hsla(240, 20%, 80%, 1);
-  --parsec-color-light-secondary-disabled: hsla(240, 20%, 90%, 1);
-  --parsec-color-light-secondary-medium: hsla(240, 20%, 93%, 1);
-  --parsec-color-light-secondary-premiere: hsla(240, 20%, 96%, 1);
-  --parsec-color-light-secondary-background: hsla(240, 20%, 98%, 1);
-  --parsec-color-light-secondary-inversed-contrast: hsla(0, 0%, 99%, 1);
-  --parsec-color-light-secondary-white: hsl(0, 0%, 100%);
+  /* secondary */
+  --parsec-color-secondary-opacity30: var(--parsec-color-light-secondary-opacity30);
+  --parsec-color-secondary-black: var(--parsec-color-light-secondary-black);
+  --parsec-color-secondary-contrast: var(--parsec-color-light-secondary-contrast);
+  --parsec-color-secondary-text: var(--parsec-color-light-secondary-text);
+  --parsec-color-secondary-soft-text: var(--parsec-color-light-secondary-soft-text);
+  --parsec-color-secondary-hard-grey: var(--parsec-color-light-secondary-hard-grey);
+  --parsec-color-secondary-grey: var(--parsec-color-light-secondary-grey);
+  --parsec-color-secondary-soft-grey: var(--parsec-color-light-secondary-soft-grey);
+  --parsec-color-secondary-light: var(--parsec-color-light-secondary-light);
+  --parsec-color-secondary-disabled: var(--parsec-color-light-secondary-disabled);
+  --parsec-color-secondary-medium: var(--parsec-color-light-secondary-medium);
+  --parsec-color-secondary-premiere: var(--parsec-color-light-secondary-premiere);
+  --parsec-color-secondary-background: var(--parsec-color-light-secondary-background);
+  --parsec-color-secondary-inversed-contrast: var(--parsec-color-light-secondary-inversed-contrast);
+  --parsec-color-secondary-white: var(--parsec-color-light-secondary-white);
+  --parsec-color-secondary-surface: var(--parsec-color-light-secondary-surface);
 
-  /* ------ alert light------ */
-  --parsec-color-light-info-50: hsla(212, 60%, 95%, 1);
-  --parsec-color-light-info-100: hsla(212, 92%, 90%, 1);
-  --parsec-color-light-info-500: hsla(212, 60%, 50%, 1);
-  --parsec-color-light-info-700: hsla(212, 90%, 30%, 1);
+  /* info */
+  --parsec-color-info-50: var(--parsec-color-light-info-50);
+  --parsec-color-info-100: var(--parsec-color-light-info-100);
+  --parsec-color-info-500: var(--parsec-color-light-info-500);
+  --parsec-color-info-700: var(--parsec-color-light-info-700);
 
-  --parsec-color-light-success-50: hsla(146, 60%, 95%, 1);
-  --parsec-color-light-success-100: hsla(146, 92%, 90%, 1);
-  --parsec-color-light-success-500: hsla(144, 60%, 50%, 1);
-  --parsec-color-light-success-700: hsla(144, 90%, 30%, 1);
+  /* success */
+  --parsec-color-success-50: var(--parsec-color-light-success-50);
+  --parsec-color-success-100: var(--parsec-color-light-success-100);
+  --parsec-color-success-500: var(--parsec-color-light-success-500);
+  --parsec-color-success-700: var(--parsec-color-light-success-700);
 
-  --parsec-color-light-warning-50: hsla(45, 60%, 95%, 1);
-  --parsec-color-light-warning-100: hsla(45, 92%, 90%, 1);
-  --parsec-color-light-warning-500: hsla(45, 60%, 50%, 1);
-  --parsec-color-light-warning-700: hsla(45, 90%, 30%, 1);
+  /* warning */
+  --parsec-color-warning-50: var(--parsec-color-light-warning-50);
+  --parsec-color-warning-100: var(--parsec-color-light-warning-100);
+  --parsec-color-warning-500: var(--parsec-color-light-warning-500);
+  --parsec-color-warning-700: var(--parsec-color-light-warning-700);
 
-  --parsec-color-light-danger-50: hsla(352, 60%, 95%, 1);
-  --parsec-color-light-danger-100: hsla(352, 92%, 90%, 1);
-  --parsec-color-light-danger-500: hsla(352, 60%, 50%, 1);
-  --parsec-color-light-danger-700: hsla(352, 90%, 30%, 1);
+  /* danger */
+  --parsec-color-danger-50: var(--parsec-color-light-danger-50);
+  --parsec-color-danger-100: var(--parsec-color-light-danger-100);
+  --parsec-color-danger-500: var(--parsec-color-light-danger-500);
+  --parsec-color-danger-700: var(--parsec-color-light-danger-700);
 
-  /* ------ tags light------ */
-  --parsec-color-tags-indigo-50: hsla(247, 100%, 95%, 1);
-  --parsec-color-tags-indigo-700: hsla(247, 100%, 30%, 1);
-  --parsec-color-tags-blue-50: var(--parsec-color-light-primary-50);
-  --parsec-color-tags-blue-700: var(--parsec-color-light-primary-700);
-  --parsec-color-tags-orange-50: hsla(28, 100%, 95%, 1);
-  --parsec-color-tags-orange-700: hsla(28, 100%, 30%, 1);
+  /* tags */
+  --parsec-color-tags-indigo-50: var(--parsec-color-light-tags-indigo-50);
+  --parsec-color-tags-indigo-700: var(--parsec-color-light-tags-indigo-700);
+  --parsec-color-tags-blue-50: var(--parsec-color-light-tags-blue-50);
+  --parsec-color-tags-blue-700: var(--parsec-color-light-tags-blue-700);
+  --parsec-color-tags-orange-50: var(--parsec-color-light-tags-orange-50);
+  --parsec-color-tags-orange-700: var(--parsec-color-light-tags-orange-700);
 
-  /* ------ scrollbar light------ */
-  --parsec-color-light-scrollbar-thumb: hsl(240, 5%, 74%);
-  --parsec-color-light-scrollbar-thumb-hover: hsl(240, 5%, 55%);
-  --parsec-color-light-scrollbar-track: hsla(0, 0%, 100%, 0);
+  /* scrollbar */
+  --parsec-color-scrollbar-thumb: var(--parsec-color-light-scrollbar-thumb);
+  --parsec-color-scrollbar-thumb-hover: var(--parsec-color-light-scrollbar-thumb-hover);
+  --parsec-color-scrollbar-track: var(--parsec-color-light-scrollbar-track);
 }

--- a/lib/theme/variables/index.scss
+++ b/lib/theme/variables/index.scss
@@ -2,6 +2,8 @@
 
 @forward 'colors';
 @forward 'colors-ionic';
+@forward 'colors-primitives';
+@forward 'colors-theme';
 @forward 'fonts';
 @forward 'radius';
 @forward 'shadows';

--- a/src/views/ComponentsPage.vue
+++ b/src/views/ComponentsPage.vue
@@ -794,7 +794,7 @@ function onSliderPlayClicked(): void {
   text-align: center;
   margin: 0;
   padding: 0;
-  color: var(--parsec-color-light-primary-800);
+  color: var(--parsec-color-primary-800);
 }
 
 .input-item {
@@ -802,7 +802,7 @@ function onSliderPlayClicked(): void {
   display: flex;
   flex-direction: column;
   align-items: start;
-  background-color: var(--parsec-color-light-secondary-white);
+  background-color: var(--parsec-color-secondary-surface);
   flex-shrink: 1;
 }
 

--- a/src/views/ComponentsPage.vue
+++ b/src/views/ComponentsPage.vue
@@ -847,7 +847,7 @@ function onSliderPlayClicked(): void {
   text-align: center;
   margin: 0;
   padding: 0;
-  color: var(--parsec-color-light-primary-800);
+  color: var(--parsec-color-primary-800);
 }
 
 .input-item {
@@ -855,7 +855,7 @@ function onSliderPlayClicked(): void {
   display: flex;
   flex-direction: column;
   align-items: start;
-  background-color: var(--parsec-color-light-secondary-white);
+  background-color: var(--parsec-color-secondary-surface);
   flex-shrink: 1;
 }
 

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -61,11 +61,11 @@ const category = ref<Category>(Category.Components);
   text-align: center;
   margin: 0;
   padding: 0;
-  color: var(--parsec-color-light-primary-800);
+  color: var(--parsec-color-primary-800);
 }
 
 ion-content {
-  --background: var(--parsec-color-light-secondary-background);
+  --background: var(--parsec-color-secondary-background);
 }
 
 #container {
@@ -74,7 +74,7 @@ ion-content {
   align-items: start;
   gap: 2rem;
   padding: 3rem;
-  background: var(--parsec-color-light-secondary-background);
+  background: var(--parsec-color-secondary-background);
 
   @include ms.responsive-breakpoint('sm') {
     padding: 2rem;

--- a/src/views/ResponsivePage.vue
+++ b/src/views/ResponsivePage.vue
@@ -103,21 +103,21 @@ const noResponsiveMixinOverlap = ref(false);
   text-align: center;
   margin: 0;
   padding: 0;
-  color: var(--parsec-color-light-primary-800);
+  color: var(--parsec-color-primary-800);
 }
 
 .responsive-mixin-block {
   display: none;
   padding: 0.5em;
   border-radius: 0.5em;
-  background: blue;
+  background: var(--parsec-color-primary-500);
   &-no-mixin {
     display: block;
     color: white;
   }
 
   @include ms.responsive-breakpoint('xxl') {
-    background: #ff0000;
+    background: var(--parsec-color-primary-700);
     &-xxl {
       display: block;
     }
@@ -128,7 +128,7 @@ const noResponsiveMixinOverlap = ref(false);
   }
 
   @include ms.responsive-breakpoint('xl') {
-    background: #ff5500;
+    background: var(--parsec-color-primary-600);
     &-xl {
       display: block;
     }
@@ -139,7 +139,7 @@ const noResponsiveMixinOverlap = ref(false);
   }
 
   @include ms.responsive-breakpoint('lg') {
-    background: #ffaa00;
+    background: var(--parsec-color-primary-400);
     &-lg {
       display: block;
     }
@@ -150,7 +150,7 @@ const noResponsiveMixinOverlap = ref(false);
   }
 
   @include ms.responsive-breakpoint('md') {
-    background: #aaff00;
+    background: var(--parsec-color-primary-300);
     &-md {
       display: block;
     }
@@ -161,7 +161,7 @@ const noResponsiveMixinOverlap = ref(false);
   }
 
   @include ms.responsive-breakpoint('sm') {
-    background: #55ff00;
+    background: var(--parsec-color-primary-200);
     &-sm {
       display: block;
     }
@@ -172,7 +172,7 @@ const noResponsiveMixinOverlap = ref(false);
   }
 
   @include ms.responsive-breakpoint('xs') {
-    background: #00ff00;
+    background: var(--parsec-color-primary-100);
     &-xs {
       display: block;
     }

--- a/src/views/ResponsivePage.vue
+++ b/src/views/ResponsivePage.vue
@@ -118,6 +118,7 @@ const noResponsiveMixinOverlap = ref(false);
 
   @include ms.responsive-breakpoint('xxl') {
     background: var(--parsec-color-primary-700);
+    color: var(--parsec-color-secondary-white);
     &-xxl {
       display: block;
     }
@@ -140,6 +141,7 @@ const noResponsiveMixinOverlap = ref(false);
 
   @include ms.responsive-breakpoint('lg') {
     background: var(--parsec-color-primary-400);
+
     &-lg {
       display: block;
     }
@@ -150,7 +152,7 @@ const noResponsiveMixinOverlap = ref(false);
   }
 
   @include ms.responsive-breakpoint('md') {
-    background: var(--parsec-color-primary-300);
+    color: var(--parsec-color-secondary-black);
     &-md {
       display: block;
     }

--- a/src/views/ServicesPage.vue
+++ b/src/views/ServicesPage.vue
@@ -150,6 +150,6 @@ async function changeLocale(event: MsDropdownChangeEvent): Promise<void> {
   text-align: center;
   margin: 0;
   padding: 0;
-  color: var(--parsec-color-light-primary-800);
+  color: var(--parsec-color-primary-800);
 }
 </style>

--- a/src/views/TransitionsPage.vue
+++ b/src/views/TransitionsPage.vue
@@ -65,7 +65,7 @@ function onNextItemSlideHorizontalClick(): void {
   text-align: center;
   margin: 0;
   padding: 0;
-  color: var(--parsec-color-light-primary-800);
+  color: var(--parsec-color-primary-800);
 }
 
 .slider-container ion-label {

--- a/src/views/example-block/ExampleBlock.vue
+++ b/src/views/example-block/ExampleBlock.vue
@@ -22,15 +22,15 @@ defineProps<{ title: Translatable }>();
   display: flex;
   flex-direction: column;
   align-items: start;
-  background-color: var(--parsec-color-light-secondary-white);
+  background-color: var(--parsec-color-secondary-surface);
   border-radius: var(--parsec-radius-12);
   box-shadow: var(--parsec-shadow-light);
   --inner-padding-end: 0;
   overflow: visible;
 
   ion-label.title-h2 {
-    background: var(--parsec-color-light-secondary-medium);
-    color: var(--parsec-color-light-secondary-text);
+    background: var(--parsec-color-secondary-medium);
+    color: var(--parsec-color-secondary-text);
     width: 100%;
     border-radius: var(--parsec-radius-8) var(--parsec-radius-8) 0 0;
     margin: 0;

--- a/src/views/settings/SettingsModal.vue
+++ b/src/views/settings/SettingsModal.vue
@@ -139,7 +139,7 @@ async function changeLang(lang: Locale): Promise<void> {
 
     // eslint-disable-next-line vue-scoped-css/no-unused-selector
     &__item {
-      color: var(--parsec-color-light-secondary-grey);
+      color: var(--parsec-color-secondary-grey);
       border-radius: var(--parsec-radius-6);
 
       .item-container {
@@ -155,13 +155,13 @@ async function changeLang(lang: Locale): Promise<void> {
       }
 
       &.radio-checked {
-        color: var(--parsec-color-light-secondary-text);
-        background: var(--parsec-color-light-secondary-premiere);
+        color: var(--parsec-color-secondary-text);
+        background: var(--parsec-color-secondary-premiere);
       }
 
       &:hover:not(.radio-checked) {
-        background: var(--parsec-color-light-secondary-premiere);
-        color: var(--parsec-color-light-secondary-text);
+        background: var(--parsec-color-secondary-premiere);
+        color: var(--parsec-color-secondary-text);
       }
 
       ion-icon {

--- a/src/views/settings/SettingsOption.vue
+++ b/src/views/settings/SettingsOption.vue
@@ -30,7 +30,7 @@ defineProps<{
   justify-content: space-between;
   align-items: center;
   padding: 0.75rem 1rem 0.75rem 0;
-  border-bottom: 1px solid var(--parsec-color-light-secondary-disabled);
+  border-bottom: 1px solid var(--parsec-color-secondary-disabled);
   gap: 1.5rem;
 
   &__content {
@@ -40,11 +40,11 @@ defineProps<{
     gap: 0.25rem;
 
     .title {
-      color: var(--parsec-color-light-primary-700);
+      color: var(--parsec-color-primary-700);
     }
 
     .description {
-      color: var(--parsec-color-light-secondary-grey);
+      color: var(--parsec-color-secondary-grey);
     }
   }
 }


### PR DESCRIPTION
Replace all direct var(--parsec-color-light-*) references in components with neutral aliases var(--parsec-color-*) that point to light theme by default via :root in _colors.scss.

Split raw color values out of _colors.scss into a dedicated _colors-light.scss file (one file per theme going forward).

Also rename secondary-white to secondary-surface where used as a background token, and replace primary-700/800 with secondary-text in dropdown/popover menus for semantic correctness.