### PR TITLE
feat(theme)/global variables

### DIFF
--- a/lib/theme/mixins/_borders.scss
+++ b/lib/theme/mixins/_borders.scss
@@ -1,0 +1,5 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+@function border($token) {
+  @return var(--parsec-border-#{$token});
+}

--- a/lib/theme/mixins/_colors.scss
+++ b/lib/theme/mixins/_colors.scss
@@ -1,4 +1,5 @@
 /* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
 
-@forward 'colors';
-@forward 'responsive' as responsive-*;
+@function color($token) {
+  @return var(--parsec-color-#{$token});
+}

--- a/lib/theme/mixins/_fonts.scss
+++ b/lib/theme/mixins/_fonts.scss
@@ -1,0 +1,5 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+@function font($token) {
+  @return var(--parsec-font-#{$token});
+}

--- a/lib/theme/mixins/_layout.scss
+++ b/lib/theme/mixins/_layout.scss
@@ -1,0 +1,5 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+@function layout($token) {
+  @return var(--parsec-layout-#{$token});
+}

--- a/lib/theme/mixins/_opacity.scss
+++ b/lib/theme/mixins/_opacity.scss
@@ -1,0 +1,5 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+@function opacity($token) {
+  @return var(--parsec-opacity-#{$token});
+}

--- a/lib/theme/mixins/_radius.scss
+++ b/lib/theme/mixins/_radius.scss
@@ -1,0 +1,5 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+@function radius($token) {
+  @return var(--parsec-radius-#{$token});
+}

--- a/lib/theme/mixins/_shadows.scss
+++ b/lib/theme/mixins/_shadows.scss
@@ -1,0 +1,5 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+@function shadow($token) {
+  @return var(--parsec-shadow-#{$token});
+}

--- a/lib/theme/mixins/_size.scss
+++ b/lib/theme/mixins/_size.scss
@@ -1,0 +1,5 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+@function size($token) {
+  @return var(--parsec-size-#{$token});
+}

--- a/lib/theme/mixins/index.scss
+++ b/lib/theme/mixins/index.scss
@@ -1,4 +1,11 @@
 /* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
 
+@forward 'borders';
 @forward 'colors';
+@forward 'fonts';
+@forward 'layout';
+@forward 'opacity';
+@forward 'radius';
+@forward 'shadows';
+@forward 'size';
 @forward 'responsive' as responsive-*;

--- a/lib/theme/variables/_borders.scss
+++ b/lib/theme/variables/_borders.scss
@@ -1,0 +1,10 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+/* **** Parsec border **** */
+
+:root {
+  --parsec-border-none: 0;
+  --parsec-border-thin: 0.0625rem;
+  --parsec-border-thick: 0.125rem;
+  --parsec-border-thicker: 0.25rem;
+}

--- a/lib/theme/variables/_colors-theme.scss
+++ b/lib/theme/variables/_colors-theme.scss
@@ -16,6 +16,9 @@
   --parsec-color-surface-elevated-subtle: var(--parsec-color-grey-800);
   --parsec-color-surface-elevated-subtle-hover: var(--parsec-color-grey-700);
 
+  --parsec-color-surface-gradient-from: var(--parsec-color-brand-500);
+  --parsec-color-surface-gradient-to: var(--parsec-color-brand-700);
+
   --parsec-color-surface-brand-default: var(--parsec-color-brand-500);
   --parsec-color-surface-brand-default-hover: var(--parsec-color-brand-600);
   --parsec-color-surface-brand-default-pressed: var(--parsec-color-brand-700);

--- a/lib/theme/variables/_fonts.scss
+++ b/lib/theme/variables/_fonts.scss
@@ -14,6 +14,76 @@
   src: url('../assets/fonts/AlbertSans-Italic-VariableFont_wght.ttf');
 }
 
+/* **** Parsec font tokens **** */
+
+:root {
+  // ----- family -----
+  --parsec-font-family-heading: 'Albert Sans';
+  --parsec-font-family-paragraph: 'Albert Sans';
+
+  // ----- weight -----
+  --parsec-font-weight-regular: 400;
+  --parsec-font-weight-medium: 500;
+  --parsec-font-weight-emphasis: 600;
+  --parsec-font-weight-bold: 700;
+
+  // ----- heading -----
+  --parsec-font-heading-h1-text-size: 2rem;
+  --parsec-font-heading-h1-line-height: 2.375rem;
+  --parsec-font-heading-h1-letter-spacing: 0.1px;
+
+  --parsec-font-heading-h2-text-size: 1.5rem;
+  --parsec-font-heading-h2-line-height: 2rem;
+  --parsec-font-heading-h2-letter-spacing: 0.1px;
+
+  --parsec-font-heading-h3-text-size: 1.25rem;
+  --parsec-font-heading-h3-line-height: 1.5rem;
+  --parsec-font-heading-h3-letter-spacing: 0.1px;
+
+  --parsec-font-heading-h4-text-size: 1.125rem;
+  --parsec-font-heading-h4-line-height: 1.375rem;
+  --parsec-font-heading-h4-letter-spacing: 0.1px;
+
+  --parsec-font-heading-h5-text-size: 1rem;
+  --parsec-font-heading-h5-line-height: 1.25rem;
+  --parsec-font-heading-h5-letter-spacing: 0.1px;
+
+  --parsec-font-heading-h6-text-size: 0.875rem;
+  --parsec-font-heading-h6-line-height: 1.125rem;
+  --parsec-font-heading-h6-letter-spacing: 0.1px;
+
+  // ----- body -----
+  --parsec-font-body-xs-text-size: 0.75rem;
+  --parsec-font-body-xs-line-height: 1.125rem;
+  --parsec-font-body-xs-letter-spacing: 0.1px;
+
+  --parsec-font-body-sm-text-size: 0.8125rem;
+  --parsec-font-body-sm-line-height: 1.125rem;
+  --parsec-font-body-sm-letter-spacing: 0.1px;
+
+  --parsec-font-body-md-text-size: 0.875rem;
+  --parsec-font-body-md-line-height: 1.375rem;
+  --parsec-font-body-md-letter-spacing: 0.1px;
+
+  --parsec-font-body-lg-text-size: 1rem;
+  --parsec-font-body-lg-line-height: 1.5rem;
+  --parsec-font-body-lg-letter-spacing: 0.1px;
+
+  --parsec-font-body-xl-text-size: 1.125rem;
+  --parsec-font-body-xl-line-height: 1.75rem;
+  --parsec-font-body-xl-letter-spacing: 0.1px;
+
+  // ----- label -----
+  --parsec-font-label-sm-text-size: 0.8125rem;
+  --parsec-font-label-sm-letter-spacing: 0.2px;
+
+  --parsec-font-label-md-text-size: 0.875rem;
+  --parsec-font-label-md-letter-spacing: 0.2px;
+
+  --parsec-font-label-lg-text-size: 1rem;
+  --parsec-font-label-lg-letter-spacing: 0.2px;
+}
+
 /* **** Parsec typography **** */
 * {
   font-synthesis: none;

--- a/lib/theme/variables/_layout.scss
+++ b/lib/theme/variables/_layout.scss
@@ -1,0 +1,31 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+/* **** Parsec layout **** */
+
+:root {
+  --parsec-layout-gap-none: 0;
+  --parsec-layout-gap-xs: 0.125rem;
+  --parsec-layout-gap-sm: 0.25rem;
+  --parsec-layout-gap-md: 0.5rem;
+  --parsec-layout-gap-lg: 0.75rem;
+  --parsec-layout-gap-xl: 1rem;
+  --parsec-layout-gap-2xl: 1.5rem;
+  --parsec-layout-gap-3xl: 2rem;
+  --parsec-layout-gap-4xl: 2.5rem;
+
+  --parsec-layout-padding-none: 0;
+  --parsec-layout-padding-2xs: 0.125rem;
+  --parsec-layout-padding-xs: 0.25rem;
+  --parsec-layout-padding-sm: 0.375rem;
+  --parsec-layout-padding-md: 0.5rem;
+  --parsec-layout-padding-lg: 0.625rem;
+  --parsec-layout-padding-xl: 0.75rem;
+  --parsec-layout-padding-2xl: 1rem;
+  --parsec-layout-padding-3xl: 1.5rem;
+  --parsec-layout-padding-4xl: 2rem;
+  --parsec-layout-padding-5xl: 2.5rem;
+  --parsec-layout-padding-6xl: 3rem;
+  --parsec-layout-padding-7xl: 4rem;
+  --parsec-layout-padding-8xl: 5rem;
+  --parsec-layout-padding-9xl: 10rem;
+}

--- a/lib/theme/variables/_opacity.scss
+++ b/lib/theme/variables/_opacity.scss
@@ -1,0 +1,8 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+/* **** Parsec opacity **** */
+
+:root {
+  --parsec-opacity-disabled: 0.4;
+  --parsec-opacity-description: 0.8;
+}

--- a/lib/theme/variables/_radius.scss
+++ b/lib/theme/variables/_radius.scss
@@ -9,8 +9,10 @@
   --parsec-radius-8: 0.5rem;
   --parsec-radius-10: 0.625rem;
   --parsec-radius-12: 0.75rem;
+  --parsec-radius-16: 1rem;
   --parsec-radius-18: 1.125rem;
   --parsec-radius-24: 1.5rem;
   --parsec-radius-32: 2rem;
   --parsec-radius-circle: 50%;
+  --parsec-radius-full: 62.4375rem;
 }

--- a/lib/theme/variables/_shadows.scss
+++ b/lib/theme/variables/_shadows.scss
@@ -1,5 +1,7 @@
 /* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
 
+@use '@lib/theme' as ms;
+
 /* **** Parsec shadow **** */
 :root {
   // ----- base shadows -----
@@ -30,4 +32,11 @@
   --parsec-shadow-input: 0px 1px 1px rgba(0, 0, 0, 0.03), 0px 3px 5px rgba(0, 0, 0, 0.02);
   --parsec-shadow-3d-light: 0px 0px 25px 0px rgba(34, 129, 254, 0.1) inset, 0px 0px 12px 0px rgba(64, 146, 255, 0.1);
   --parsec-shadow-3d-strong: 0px 0px 49px 0px rgba(0, 0, 0, 0.05), 0px 4px 84px 0px rgba(58, 160, 255, 0.25) inset;
+
+  --parsec-shadow-focus-brand: 0 0 0 3px #{ms.color('shadow-brand-moderate')};
+  --parsec-shadow-focus-neutral: 0 0 0 3px #{ms.color('shadow-neutral-moderate')};
+  --parsec-shadow-focus-error: 0 0 0 3px #{ms.color('shadow-error-moderate')};
+  --parsec-shadow-focus-success: 0 0 0 3px #{ms.color('shadow-success-moderate')};
+  --parsec-shadow-focus-warning: 0 0 0 3px #{ms.color('shadow-warning-moderate')};
+  --parsec-shadow-focus-information: 0 0 0 3px #{ms.color('shadow-information-moderate')};
 }

--- a/lib/theme/variables/_size.scss
+++ b/lib/theme/variables/_size.scss
@@ -1,0 +1,14 @@
+/* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
+
+/* **** Parsec size **** */
+
+:root {
+  --parsec-size-2xs: 0.75rem;
+  --parsec-size-xs: 1rem;
+  --parsec-size-sm: 1.25rem;
+  --parsec-size-md: 1.5rem;
+  --parsec-size-lg: 2rem;
+  --parsec-size-xl: 2.5rem;
+  --parsec-size-2xl: 3rem;
+  --parsec-size-3xl: 3.5rem;
+}

--- a/lib/theme/variables/index.scss
+++ b/lib/theme/variables/index.scss
@@ -1,11 +1,15 @@
 /* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
 
+@forward 'borders';
 @forward 'colors';
 @forward 'colors-ionic';
 @forward 'colors-primitives';
 @forward 'colors-theme';
 @forward 'fonts';
+@forward 'layout';
+@forward 'opacity';
 @forward 'radius';
 @forward 'shadows';
+@forward 'size';
 @forward 'spacing';
 @forward 'width';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,8 @@ import { UserConfig, defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
 
+const themeDir = path.resolve(import.meta.dirname, 'lib/theme');
+
 // https://vitejs.dev/config/
 const config: UserConfig = {
   plugins: [
@@ -45,6 +47,18 @@ const config: UserConfig = {
       '@': path.resolve(import.meta.dirname, './src'),
       '@lib': path.resolve(import.meta.dirname, './lib'),
       '@megashark': path.resolve(import.meta.dirname, './lib'),
+    },
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        additionalData: (source: string, filename: string): string => {
+          if (filename.startsWith(themeDir)) {
+            return source;
+          }
+          return `@use '@lib/theme' as ms;\n${source}`;
+        },
+      },
     },
   },
   // The 'test' property is specific to vitest (see reference types directive above)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,8 +9,6 @@ import { UserConfig, defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
 
-const themeDir = path.resolve(import.meta.dirname, 'lib/theme');
-
 // https://vitejs.dev/config/
 const config: UserConfig = {
   plugins: [
@@ -47,18 +45,6 @@ const config: UserConfig = {
       '@': path.resolve(import.meta.dirname, './src'),
       '@lib': path.resolve(import.meta.dirname, './lib'),
       '@megashark': path.resolve(import.meta.dirname, './lib'),
-    },
-  },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        additionalData: (source: string, filename: string): string => {
-          if (filename.startsWith(themeDir)) {
-            return source;
-          }
-          return `@use '@lib/theme' as ms;\n${source}`;
-        },
-      },
     },
   },
   // The 'test' property is specific to vitest (see reference types directive above)


### PR DESCRIPTION
## New CSS tokens (custom properties)
- `_borders.scss`: `--parsec-border-{none,thin,thick,thicker}`
- `_layout.scss`: `--parsec-layout-gap-*` and `--parsec-layout-padding-*` (scale xs → 9xl)
- `_opacity.scss`: `--parsec-opacity-{disabled,description}`
- `_size.scss: `--parsec-size-*` (2xs → 3xl)
- `_fonts.scss`: addition of a complete set of typographic tokens (family, weight, heading-h1..h6, body-xs..xl, label-sm..lg) — until now, only @font-face was available
- `_radius.scss: adds `--parsec-radius-16` and `--parsec-radius-full`
- `_shadows.scss`: adds 6 tokens `--parsec-shadow-focus-{brand,neutral,error,success,warning,information}, constructed using the `color()` function on shadow-*-moderate tokens
- `_colors-theme.scss`: adds `--parsec-color-surface-gradient-{from,to}`